### PR TITLE
[Bugfix] crash when parsing legacy doc

### DIFF
--- a/uport-did/src/main/java/me/uport/sdk/uportdid/UportIdentityDocument.kt
+++ b/uport-did/src/main/java/me/uport/sdk/uportdid/UportIdentityDocument.kt
@@ -90,12 +90,12 @@ data class UportIdentityDocument(
 
     companion object {
 
+        fun fromJson(json: String): UportIdentityDocument? = jsonParser.parse(serializer(), json)
+
         /**
          * Attempts to deserialize a json string into a profile document
          */
         private val jsonParser = Json(JsonConfiguration(encodeDefaults = false, strictMode = false))
-
-        fun fromJson(json: String): UportIdentityDocument? = jsonParser.parse(serializer(), json)
     }
 }
 

--- a/uport-did/src/main/java/me/uport/sdk/uportdid/UportIdentityDocument.kt
+++ b/uport-did/src/main/java/me/uport/sdk/uportdid/UportIdentityDocument.kt
@@ -5,6 +5,7 @@ package me.uport.sdk.uportdid
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 import me.uport.sdk.universaldid.AuthenticationEntry
 import me.uport.sdk.universaldid.DIDDocument
 import me.uport.sdk.universaldid.PublicKeyEntry
@@ -92,7 +93,9 @@ data class UportIdentityDocument(
         /**
          * Attempts to deserialize a json string into a profile document
          */
-        fun fromJson(json: String): UportIdentityDocument? = Json.parse(serializer(), json)
+        private val jsonParser = Json(JsonConfiguration(encodeDefaults = false, strictMode = false))
+
+        fun fromJson(json: String): UportIdentityDocument? = jsonParser.parse(serializer(), json)
     }
 }
 

--- a/uport-did/src/test/java/me/uport/sdk/uportdid/UportIdentityDocumentTest.kt
+++ b/uport-did/src/test/java/me/uport/sdk/uportdid/UportIdentityDocumentTest.kt
@@ -1,0 +1,17 @@
+@file:Suppress("DEPRECATION")
+
+package me.uport.sdk.uportdid
+
+import assertk.assertThat
+import assertk.assertions.isNotNull
+import org.junit.Test
+
+class UportIdentityDocumentTest {
+
+    @Test
+    fun `can parse legacy Identity document`() {
+        val legacyDoc = """{"name":"uPort Demo","@type":"App","publicKey":"0x04171fcc7654cad14745b9835bc534d8e59038ae6929c793d7f8dd2c934580ca39ff1e2de3d7ef69a8daba5e5590d3ec80486a273cbe2bd1b76ebd01f949b41463","description":"Demo App","url":"demo.uport.me","image":{"contentUrl":"/ipfs/Qmez4bdFmxPknbAoGzHmpjpLjQFChq39h5UMPGiwUHgt8f"},"address":"2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG"}"""
+        val parsed = UportIdentityDocument.fromJson(legacyDoc)
+        assertThat(parsed).isNotNull()
+    }
+}


### PR DESCRIPTION
### What's here
This fixes https://www.pivotaltracker.com/story/show/166061641

### Testing
`./gradlew test` also runs the regression test that was added to reproduce the bug.
(see `'can parse legacy Identity document'()` test in `UportIdentityDocumentTest.kt`)

### Note
This is blocking https://github.com/uport-project/uport-android-sdk/pull/97