### PR TITLE
[Dependency] Claims support for JWTPayload

### DIFF
--- a/jwt/src/main/java/me/uport/sdk/jwt/model/JwtPayload.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/model/JwtPayload.kt
@@ -4,50 +4,59 @@ import com.squareup.moshi.Json
 
 data class JwtPayload(
 
-    /**
-     * General
-     */
-    val iss: String = "", //Cannot be null for signature verification
-    val iat: Long? = null,
-    val sub: String? = null,
-    val aud: String? = null,
-    val exp: Long? = null,
-    val callback: String? = null,
-    val type: String? = null,
+        /**
+         * General
+         */
+        val iss: String = "", //Cannot be null for signature verification
+        val iat: Long? = null,
+        val sub: String? = null,
+        val aud: String? = null,
+        val exp: Long? = null,
+        val callback: String? = null,
+        val type: String? = null,
 
-    /**
-     * Specific to selective disclosure REQUEST
-     */
-    val net: String? = null,
-    val act: String? = null,
-    val requested: List<String>? = null,
-    val verified: List<String>? = null,
-    val permissions: List<String>? = null,
+        /**
+         * Specific to selective disclosure REQUEST
+         */
+        val net: String? = null,
+        val act: String? = null,
+        val requested: List<String>? = null,
+        val verified: List<String>? = null,
+        val permissions: List<String>? = null,
 
-    /**
-     * Specific to selective disclosure RESPONSE
-     * Also includes verified
-     */
-    val req: String? = null, //original jwt request, REQUIRED for sign selective disclosure responses
-    val nad: String? = null, //The MNID of the Ethereum account requested using act in the Selective Disclosure Request
-    val dad: String? = null, //The devicekey as a regular hex encoded ethereum address as requested using act='devicekey' in the Selective Disclosure Request
-    //val own: String?, //The self signed claims requested from a user.
-    @Json(name = "own") val own: Map<String, String>? = null,
-    val capabilities: List<String>? = null, //An array of JWT tokens giving client app the permissions requested. Currently a token allowing them to send push notifications
+        /**
+         * Specific to selective disclosure RESPONSE
+         * Also includes verified
+         */
+        val req: String? = null, //original jwt request, REQUIRED for sign selective disclosure responses
+        val nad: String? = null, //The MNID of the Ethereum account requested using act in the Selective Disclosure Request
+        val dad: String? = null, //The devicekey as a regular hex encoded ethereum address as requested using act='devicekey' in the Selective Disclosure Request
+        //val own: String?, //The self signed responseClaims requested from a user.
+        @Json(name = "own") val own: Map<String, String>? = null,
+        val capabilities: List<String>? = null, //An array of JWT tokens giving client app the permissions requested. Currently a token allowing them to send push notifications
 
-    /**
-     * Specific to Verification
-     * Also includes iss, sub, iat, exp, claim
-     */
-    //val claims: Map<String, Any>?, //An object containing one or more claims about sub eg: {"name":"Carol Crypteau"}
-    @Json(name = "claim") val claims: Map<String, Any>? = null,
-    /**
-     * Specific to Private Chain
-     * Also includes dad
-     */
-    val ctl: String? = null, //Ethereum address of the Meta Identity Manager used to control the account
-    val reg: String? = null, //Ethereum address of the Uport Registry used on private chain
-    val rel: String? = null, //Url of relay service for providing gas on private network
-    val fct: String? = null, //Url of fueling service for providing gas on private network
-    val acc: String? = null //Fuel token used to authenticate on above fct url
+        /**
+         * Specific to Verification
+         * Also includes iss, sub, iat, exp, claim
+         */
+        //val responseClaims: Map<String, Any>?, //An object containing one or more responseClaims about sub eg: {"name":"Carol Crypteau"}
+        @Json(name = "claim") val responseClaims: Map<String, Any>? = null,
+
+        /**
+         * Specific to Selective Disclosure
+         * For requesting verifiables and user information
+         * This replaces requested and verified
+         */
+        //val requestClaims: Map<String, Any>?, //An object containing one or more request claims [specs](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md#claims-spec)
+        @Json(name = "claim") val requestClaims: Map<String, Any>? = null,
+
+        /**
+         * Specific to Private Chain
+         * Also includes dad
+         */
+        val ctl: String? = null, //Ethereum address of the Meta Identity Manager used to control the account
+        val reg: String? = null, //Ethereum address of the Uport Registry used on private chain
+        val rel: String? = null, //Url of relay service for providing gas on private network
+        val fct: String? = null, //Url of fueling service for providing gas on private network
+        val acc: String? = null //Fuel token used to authenticate on above fct url
 )

--- a/jwt/src/main/java/me/uport/sdk/jwt/model/JwtPayload.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/model/JwtPayload.kt
@@ -48,7 +48,7 @@ data class JwtPayload(
          * This replaces requested and verified
          */
         //val requestClaims: Map<String, Any>?, //An object containing one or more request claims [specs](https://github.com/uport-project/specs/blob/develop/messages/sharereq.md#claims-spec)
-        @Json(name = "claim") val requestClaims: Map<String, Any>? = null,
+        @Json(name = "claims") val requestClaims: Map<String, Any>? = null,
 
         /**
          * Specific to Private Chain

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTDecodeTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTDecodeTest.kt
@@ -61,7 +61,7 @@ class JWTDecodeTest {
         val (header, payload) = JWTTools().decode(validVerificationToken)
         val nameClaim = mapOf("name" to "Bob", "gender" to "male")
         assertThat(header.typ).isEqualTo("JWT")
-        assertThat(payload.claims).isEqualTo(nameClaim)
+        assertThat(payload.responseClaims).isEqualTo(nameClaim)
         assertThat(payload.iss).isEqualTo("did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
     }
 

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -13,7 +13,6 @@ import me.uport.sdk.ethrdid.EthrDIDResolver
 import me.uport.sdk.jsonrpc.JsonRPC
 import me.uport.sdk.jwt.JWTUtils.Companion.normalizeKnownDID
 import me.uport.sdk.jwt.model.JwtPayload
-import me.uport.sdk.jwt.test.EthrDIDTestHelpers
 import me.uport.sdk.signer.KPSigner
 import me.uport.sdk.testhelpers.TestTimeProvider
 import me.uport.sdk.testhelpers.coAssert
@@ -72,7 +71,7 @@ class JWTToolsJVMTest {
         dad = null,
         own = null,
         capabilities = null,
-        claims = null,
+        responseClaims = null,
         ctl = null,
         reg = null,
         rel = null,
@@ -100,7 +99,7 @@ class JWTToolsJVMTest {
         dad = null,
         own = null,
         capabilities = null,
-        claims = null,
+        responseClaims = null,
         ctl = null,
         reg = null,
         rel = null,
@@ -428,7 +427,7 @@ class JWTToolsJVMTest {
         val tested = JWTTools(TestTimeProvider(12345678000L))
 
         val payload = mapOf(
-            "claims" to mapOf("name" to "R Daneel Olivaw")
+            "responseClaims" to mapOf("name" to "R Daneel Olivaw")
         )
 
         val signer = KPSigner("0x54ece214d38fe6b46110a21c69fd55230f09688bf85b95fc7c1e4e160441ece1")

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -436,7 +436,7 @@ class JWTToolsJVMTest {
 
         val jwt = tested.createJWT(payload, issuerDID, signer)
         assertThat(jwt)
-            .isEqualTo("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJjbGFpbXMiOnsibmFtZSI6IlIgRGFuZWVsIE9saXZhdyJ9LCJpYXQiOjEyMzQ1Njc4LCJleHAiOjEyMzQ1OTc4LCJpc3MiOiJkaWQ6ZXRocjoweDQxMjNjYmQxNDNiNTVjMDZlNDUxZmYyNTNhZjA5Mjg2YjY4N2E5NTAifQ.o6eDKYjHJnak1ylkpe9g8krxvK9UEhKf-1T0EYhH8pGyb8MjOEepRJi8DYlVEnZno0DkVYXQCf3u1i_HThBKtAA")
+            .isEqualTo("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJyZXNwb25zZUNsYWltcyI6eyJuYW1lIjoiUiBEYW5lZWwgT2xpdmF3In0sImlhdCI6MTIzNDU2NzgsImV4cCI6MTIzNDU5NzgsImlzcyI6ImRpZDpldGhyOjB4NDEyM2NiZDE0M2I1NWMwNmU0NTFmZjI1M2FmMDkyODZiNjg3YTk1MCJ9.ZQYSH5ZxUOcaZoCPatol6p7aV_scaJ2bpUxgRT3KllAEr-S5iqEvlkQHCuF7_dBig3qioPwEwNU5AiJ8tGxwZgE")
     }
 
     @Test

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -13,6 +13,7 @@ import me.uport.sdk.ethrdid.EthrDIDResolver
 import me.uport.sdk.jsonrpc.JsonRPC
 import me.uport.sdk.jwt.JWTUtils.Companion.normalizeKnownDID
 import me.uport.sdk.jwt.model.JwtPayload
+import me.uport.sdk.jwt.test.EthrDIDTestHelpers
 import me.uport.sdk.signer.KPSigner
 import me.uport.sdk.testhelpers.TestTimeProvider
 import me.uport.sdk.testhelpers.coAssert


### PR DESCRIPTION
#### What's Here
This is a dependency for another PR https://github.com/uport-project/uport-android-sdk/pull/99

It adds a new property `requestClaims`  to the JWTPayload, which can be used when making a selective disclosure request. 

To prevent confusion with the previous JWTPayload property `claim` which is specific to the response from a Verified Claim request flow has been renamed to `responseClaims`. 

#### Testing
Run the gradle command `./gradlew test cC --no-parallel`