### PR TITLE
Adding support for "web" did method

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ We currently support the following DID methods:
 
 - [`ethr`](https://github.com/uport-project/ethr-did-resolver)
 - [`uport`](https://github.com/uport-project/uport-did-resolver)
-- [`https`](https://github.com/uport-project/https-did-resolver)
+- [`web`](https://github.com/uport-project/https-did-resolver)
+- [`https`](https://github.com/uport-project/https-did-resolver) *DEPRECATED*
 
 Defaults are automatically installed but you can customize to fit your needs.
 

--- a/https-did/src/main/java/me/uport/sdk/httpsdid/HttpsDIDResolver.kt
+++ b/https-did/src/main/java/me/uport/sdk/httpsdid/HttpsDIDResolver.kt
@@ -12,6 +12,7 @@ import me.uport.sdk.universaldid.DidResolverError
  *
  * Example https did: "did:https:example.com"
  */
+@Deprecated(message = "the `https` method has been deprecated in favor of the `web` method. Use the `WebDIDResolver` to make the transition")
 open class HttpsDIDResolver(private val httpClient: HttpClient = HttpClient()) : DIDResolver {
     override val method: String = "https"
 

--- a/https-did/src/main/java/me/uport/sdk/httpsdid/WebDIDResolver.kt
+++ b/https-did/src/main/java/me/uport/sdk/httpsdid/WebDIDResolver.kt
@@ -1,0 +1,51 @@
+package me.uport.sdk.httpsdid
+
+import me.uport.sdk.core.HttpClient
+import me.uport.sdk.universaldid.BlankDocumentError
+import me.uport.sdk.universaldid.DIDResolver
+import me.uport.sdk.universaldid.DidResolverError
+
+/**
+ * This is a DID resolver implementation that supports the "web" DID method.
+ * It accepts https-did strings and produces a document described at:
+ * https://w3c-ccg.github.io/did-spec/#did-documents
+ *
+ * Example https did: "did:web:example.com"
+ */
+open class WebDIDResolver(private val httpClient: HttpClient = HttpClient()) : DIDResolver {
+    override val method: String = "web"
+
+    override suspend fun resolve(did: String): HttpsDIDDocument {
+        if (canResolve(did)) {
+            val (_, domain) = parseDIDString(did)
+            val ddoString = getProfileDocument(domain)
+            if (ddoString.isBlank()) {
+                throw BlankDocumentError("no profile document found for `$did`")
+            }
+            return HttpsDIDDocument.fromJson(ddoString)
+        } else {
+            throw DidResolverError("The DID('$did') cannot be resolved by the HTTPS DID resolver")
+        }
+    }
+
+    override fun canResolve(potentialDID: String): Boolean {
+        val (method, _) = parseDIDString(potentialDID)
+        return (method == this.method)
+    }
+
+
+    private suspend fun getProfileDocument(domain: String): String {
+        val url = "https://$domain/.well-known/did.json"
+        return httpClient.urlGet(url)
+    }
+
+    companion object {
+        private val uportDIDPattern = "^(did:(web):)?([-a-zA-Z0-9+&@#/%?=~_|!:,.;]*[-a-zA-Z0-9+&@#/%=~_|])".toRegex()
+
+        internal fun parseDIDString(did: String): Pair<String, String> {
+            val matchResult = uportDIDPattern.find(did) ?: return ("" to did)
+            val (_, method, domain) = matchResult.destructured
+            return (method to domain)
+        }
+    }
+}

--- a/https-did/src/test/java/me/uport/sdk/httpsdid/WebDIDResolverTest.kt
+++ b/https-did/src/test/java/me/uport/sdk/httpsdid/WebDIDResolverTest.kt
@@ -18,23 +18,23 @@ import me.uport.sdk.universaldid.PublicKeyType
 import org.junit.Test
 import java.io.IOException
 
-class HttpsDIDResolverTest {
+class WebDIDResolverTest {
 
     private val exampleDidDoc = HttpsDIDDocument(
         context = "https://w3id.org/did/v1",
-        id = "did:https:example.com",
+        id = "did:web:example.com",
         publicKey = listOf(
             PublicKeyEntry(
-                id = "did:https:example.com",
+                id = "did:web:example.com",
                 type = PublicKeyType.Secp256k1VerificationKey2018,
-                owner = "did:https:example.com",
+                owner = "did:web:example.com",
                 ethereumAddress = "0x3c7d65d6daf5df62378874d35fa3626100af9d85"
             )
         ),
         authentication = listOf(
             AuthenticationEntry(
                 type = PublicKeyType.Secp256k1SignatureAuthentication2018,
-                publicKey = "did:https:example.com#owner"
+                publicKey = "did:web:example.com#owner"
             )
         ),
         service = emptyList()
@@ -44,10 +44,10 @@ class HttpsDIDResolverTest {
     @Test
     fun `can resolve valid dids`() {
         listOf(
-            "did:https:example.com",
-            "did:https:example.ngrok.com#owner"
+            "did:web:example.com",
+            "did:web:example.ngrok.com#owner"
         ).forEach {
-            assertThat(HttpsDIDResolver().canResolve(it)).isTrue()
+            assertThat(WebDIDResolver().canResolve(it)).isTrue()
         }
 
     }
@@ -58,18 +58,18 @@ class HttpsDIDResolverTest {
             "did:something:example.com", //different method
             "example.com"
         ).forEach {
-            assertThat(HttpsDIDResolver().canResolve(it)).isFalse()
+            assertThat(WebDIDResolver().canResolve(it)).isFalse()
         }
     }
 
     @Test
     fun `fails when the endpoint doesn't provide a DID document`() = runBlocking {
         val http = mockk<HttpClient>()
-        val tested = HttpsDIDResolver(http)
+        val tested = WebDIDResolver(http)
         coEvery { http.urlGet(any()) } returns ""
 
         coAssert {
-            tested.resolve("did:https:example.com")
+            tested.resolve("did:web:example.com")
         }.thrownError {
             isInstanceOf(
                 listOf(
@@ -86,11 +86,11 @@ class HttpsDIDResolverTest {
     fun `resolves document`() = runBlocking {
 
         val http = mockk<HttpClient>()
-        val tested = HttpsDIDResolver(http)
+        val tested = WebDIDResolver(http)
 
         coEvery { http.urlGet(any()) } returns exampleDidDoc.toJson()
 
-        val response = tested.resolve("did:https:example.com")
+        val response = tested.resolve("did:web:example.com")
         assertThat(response).isEqualTo(exampleDidDoc)
     }
 


### PR DESCRIPTION
#### What's Here
This PR resolves the requirements stated in Pivotal Tracker https://www.pivotaltracker.com/story/show/166122527
I created a new DIDResolver called `WebDIDResolver` which supports the `web` did method, then deprecated the `HttpsDIDResolver` which paves way for the `web` did eventually replacing the `https` did.

Tests have been duplicated and the README.md has been updated.

#### Testing
Run the gradle command ./gradlew test cC --no-parallel