### PR TITLE
[Do not merge][Support] 166983459 java calling conventions

### DIFF
--- a/jwt-java/build.gradle
+++ b/jwt-java/build.gradle
@@ -1,5 +1,9 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+apply plugin: "java-library"
+apply plugin: "kotlin"
+apply plugin: "maven"
+apply plugin: "com.jfrog.bintray"
+
+project.ext.description = "tools for creating and verifying JWTs that use uPort algorithms, usable in a JAVA context"
 
 dependencies {
     implementation project(":jwt")

--- a/jwt-java/build.gradle
+++ b/jwt-java/build.gradle
@@ -1,0 +1,14 @@
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+
+dependencies {
+    implementation project(":jwt")
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutines_version"
+
+    testImplementation "junit:junit:$junit_version"
+    testImplementation "com.github.uport-project.kotlin-common:test-helpers:$uport_kotlin_common_version"
+    testImplementation project(":jwt-test")
+}
+
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"

--- a/jwt-java/src/main/java/me/uport/sdk/jwtjava/JWTTools.kt
+++ b/jwt-java/src/main/java/me/uport/sdk/jwtjava/JWTTools.kt
@@ -1,0 +1,117 @@
+package me.uport.sdk.jwtjava
+
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
+import me.uport.sdk.core.EthNetwork
+import me.uport.sdk.core.ITimeProvider
+import me.uport.sdk.core.SystemTimeProvider
+import me.uport.sdk.jwt.InvalidJWTException
+import me.uport.sdk.jwt.JWTTools as KotlinJWTTools
+import me.uport.sdk.jwt.model.JwtHeader
+import me.uport.sdk.jwt.model.JwtPayload
+import me.uport.sdk.signer.Signer
+import me.uport.sdk.universaldid.DIDResolver
+import me.uport.sdk.universaldid.UniversalDID
+import java.util.concurrent.CompletableFuture
+
+/**
+ * Tools for Verifying, Creating, and Decoding uport JWTs
+ *
+ * @param timeProvider an [ITimeProvider] that can be used for "was valid at ..." verifications
+ * or to emit short lived tokens for future use.
+ * It defaults to a [SystemTimeProvider]
+ *
+ * @param preferredNetwork an [EthNetwork] that can be used to initialize [DIDResolver]s that are
+ * potentially missing from the [UniversalDID] resolver.
+ * **This does not take effect if resolvers are already registered.**
+ * If this param is `null`, then default networks will be used
+ * (`mainnet` for Ethr DID and `rinkeby` for uPort DID ).
+ */
+class JWTTools(
+    private val timeProvider: ITimeProvider = SystemTimeProvider,
+    private val preferredNetwork: EthNetwork? = null
+) {
+
+    private val wrappedJWTTools = KotlinJWTTools(timeProvider, preferredNetwork)
+
+    /**
+     * This method creates a signed JWT from a [payload] Map and an abstracted [Signer]
+     * You're also supposed to pass the [issuerDID] and can configure the algorithm used and expiry time
+     *
+     * @param payload a map containing the fields forming the payload of this JWT
+     * @param issuerDID a DID string that will be set as the `iss` field in the JWT payload.
+     *                  The signature produced by the signer should correspond to this DID.
+     *                  If the `iss` field is already part of the [payload], that will get overwritten.
+     *                  **The [issuerDID] is NOT checked for format, nor for a match with the signer.**
+     * @param signer a [Signer] that will produce the signature section of this JWT.
+     *                  The signature should correspond to the [issuerDID].
+     * @param expiresInSeconds number of seconds of validity of this JWT. You may omit this param if
+     *                  an `exp` timestamp is already part of the [payload].
+     *                  If there is no `exp` field in the payload and the param is not specified,
+     *                  it defaults to [DEFAULT_JWT_VALIDITY_SECONDS]
+     *                  If this param is negative or if `payload["exp"]` is explicitly set to `null`,
+     *                  the resulting JWT will not have an `exp` field
+     * @param algorithm defaults to `ES256K-R`. The signing algorithm for this JWT.
+     *                  Supported types are `ES256K` for uport DID and `ES256K-R` for ethr-did and the rest
+     *
+     */
+    fun createAsync(
+        payload: Map<String, Any?>,
+        issuerDID: String,
+        signer: Signer,
+        expiresInSeconds: Long = KotlinJWTTools.DEFAULT_JWT_VALIDITY_SECONDS,
+        algorithm: String = JwtHeader.ES256K_R
+    ): CompletableFuture<String> =
+        GlobalScope.future {
+            wrappedJWTTools.createJWT(
+                payload,
+                issuerDID,
+                signer,
+                expiresInSeconds,
+                algorithm
+            )
+        }
+
+    /**
+     * Verifies a jwt [token]
+     * @param token the jwt token to be verified
+     * @param auth if this param is `true` the public key list that this token is checked against is filtered to the
+     *          entries in the `authentication` entries in the DID document of the issuer of the token.
+     * @param audience the audience that should be able to verify this token. This is usually a DID but can also be a
+     *          callback URL for situations where the token represents a response or a bearer token.
+     * @throws InvalidJWTException when the current time is not within the time range of payload `iat` and `exp`
+     *          , when no public key matches are found in the DID document
+     *          , when the `audience` does not match the intended audience (`aud` field)
+     * @return a [JwtPayload] if the verification is successful and `null` if it fails
+     */
+    fun verifyAsync(
+        token: String,
+        auth: Boolean = false,
+        audience: String? = null
+    ): CompletableFuture<JwtPayload> =
+        GlobalScope.future {
+            wrappedJWTTools.verify(token, auth, audience)
+        }
+
+    /**
+     * Decodes a jwt [token] into a Triple (header, payload, signature), where the payload is converted to a
+     * Map object wth all the corresponding JSON fields.
+     *
+     * @param token is a string of 3 parts separated by .
+     * @throws InvalidJWTException when the header or payload are empty or when they don't start with { (invalid json)
+     * @return the JWT Header,Payload and signature as parsed objects
+     */
+    fun decodeRaw(token: String): Triple<JwtHeader, Map<String, Any?>, ByteArray> =
+        wrappedJWTTools.decodeRaw(token)
+
+    /**
+     * Decodes a jwt [token] into a Triple (header, payload, signature), where the payload is converted to a
+     * [JwtPayload] object with the known JWT fields.
+     *
+     * @param token is a string of 3 parts separated by .
+     * @throws InvalidJWTException when the header or payload are empty or when they don't start with { (invalid json)
+     * @return the JWT Header,Payload and signature as parsed objects
+     */
+    fun decode(token: String): Triple<JwtHeader, JwtPayload, ByteArray> =
+        wrappedJWTTools.decode(token)
+}

--- a/jwt-java/src/main/java/me/uport/sdk/jwtjava/JWTTools.kt
+++ b/jwt-java/src/main/java/me/uport/sdk/jwtjava/JWTTools.kt
@@ -55,7 +55,7 @@ class JWTTools(
      *                  Supported types are `ES256K` for uport DID and `ES256K-R` for ethr-did and the rest
      *
      */
-    fun createAsync(
+    fun createJWT(
         payload: Map<String, Any?>,
         issuerDID: String,
         signer: Signer,
@@ -84,7 +84,7 @@ class JWTTools(
      *          , when the `audience` does not match the intended audience (`aud` field)
      * @return a [JwtPayload] if the verification is successful and `null` if it fails
      */
-    fun verifyAsync(
+    fun verify(
         token: String,
         auth: Boolean = false,
         audience: String? = null

--- a/jwt-java/src/test/java/me/uport/sdk/jwtjava/JWTToolsTest.java
+++ b/jwt-java/src/test/java/me/uport/sdk/jwtjava/JWTToolsTest.java
@@ -1,0 +1,76 @@
+package me.uport.sdk.jwtjava;
+
+import kotlin.Triple;
+import me.uport.sdk.ethrdid.EthrDIDResolver;
+import me.uport.sdk.jwt.model.JwtHeader;
+import me.uport.sdk.jwt.model.JwtPayload;
+import me.uport.sdk.jwt.test.EthrDIDTestHelpers;
+import me.uport.sdk.signer.KPSigner;
+import me.uport.sdk.testhelpers.TestTimeProvider;
+import me.uport.sdk.universaldid.UniversalDID;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.Assert.assertEquals;
+
+public class JWTToolsTest {
+
+    @Test
+    public void creates_a_token_with_completable_future_result() {
+
+        JWTTools tools = new JWTTools(
+                new TestTimeProvider(1234L),
+                null
+        );
+
+        HashMap<String, Object> put = new HashMap<>();
+        put.put("hello", "world");
+
+        KPSigner signer = new KPSigner("0x1234");
+        String issuer = "did:ethr:" + signer.getAddress();
+        CompletableFuture<String> jwtFuture = tools.createAsync(
+                put,
+                issuer,
+                signer,
+                -1,
+                JwtHeader.ES256K);
+
+        String token = jwtFuture.join();
+        assertEquals("eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxLCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.04NvsvvAQH75H0k28fC2Pu9L9oSC5vQhF6RkWYCQXvl8TtVKugwJaY1seTiHl0N0yQcIn0GT26L9djDrc95DSg", token);
+    }
+
+    @Test
+    public void verifies_a_token_using_completable_future_result() {
+
+        EthrDIDResolver resolver = EthrDIDTestHelpers.getMockResolverForAddress("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed");
+        UniversalDID.INSTANCE.registerResolver(resolver);
+
+        JWTTools tools = new JWTTools();
+        CompletableFuture<JwtPayload> jwtPayloadCompletableFuture =
+                tools.verifyAsync(
+                        "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNTYxOTcxMTE5LCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.t5o1vzZExArlrrTVHmwtti7fnicXqvWrX6SS3F-Lu3budH7p6zQHjG8X7EvUTRUxhvr-eENCbXeteSE4rgF7MA",
+                        false,
+                        null);
+
+        JwtPayload result = jwtPayloadCompletableFuture.join();
+        assertEquals("did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed", result.getIss());
+    }
+
+    @Test
+    public void decodes_a_token_into_triple_with_typed_payload() {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNTYxOTcxMTE5LCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.t5o1vzZExArlrrTVHmwtti7fnicXqvWrX6SS3F-Lu3budH7p6zQHjG8X7EvUTRUxhvr-eENCbXeteSE4rgF7MA";
+        Triple<JwtHeader, JwtPayload, byte[]> decodedTriple = new JWTTools().decode(token);
+        assertEquals(decodedTriple.component2().getIss(), "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed");
+    }
+
+    @Test
+    public void decodes_a_token_into_triple_with_map_payload() {
+        String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNTYxOTcxMTE5LCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.t5o1vzZExArlrrTVHmwtti7fnicXqvWrX6SS3F-Lu3budH7p6zQHjG8X7EvUTRUxhvr-eENCbXeteSE4rgF7MA";
+        Triple<JwtHeader, Map<String, Object>, byte[]> decodedTriple = new JWTTools().decodeRaw(token);
+        assertEquals(decodedTriple.component2().get("iss"), "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed");
+    }
+
+}

--- a/jwt-java/src/test/java/me/uport/sdk/jwtjava/JWTToolsTest.java
+++ b/jwt-java/src/test/java/me/uport/sdk/jwtjava/JWTToolsTest.java
@@ -31,7 +31,7 @@ public class JWTToolsTest {
 
         KPSigner signer = new KPSigner("0x1234");
         String issuer = "did:ethr:" + signer.getAddress();
-        CompletableFuture<String> jwtFuture = tools.createAsync(
+        CompletableFuture<String> jwtFuture = tools.createJWT(
                 put,
                 issuer,
                 signer,
@@ -50,7 +50,7 @@ public class JWTToolsTest {
 
         JWTTools tools = new JWTTools();
         CompletableFuture<JwtPayload> jwtPayloadCompletableFuture =
-                tools.verifyAsync(
+                tools.verify(
                         "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNTYxOTcxMTE5LCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.t5o1vzZExArlrrTVHmwtti7fnicXqvWrX6SS3F-Lu3budH7p6zQHjG8X7EvUTRUxhvr-eENCbXeteSE4rgF7MA",
                         false,
                         null);

--- a/jwt-test/build.gradle
+++ b/jwt-test/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation project(":ethr-did")
+    api "com.github.uport-project.kotlin-common:test-helpers:$uport_kotlin_common_version"
+    implementation "io.mockk:mockk:$mockk_version"
 
     testImplementation "junit:junit:$junit_version"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"

--- a/jwt-test/src/main/java/me/uport/sdk/jwt/test/EthrDIDTestHelpers.kt
+++ b/jwt-test/src/main/java/me/uport/sdk/jwt/test/EthrDIDTestHelpers.kt
@@ -1,14 +1,42 @@
 package me.uport.sdk.jwt.test
 
+import io.mockk.coEvery
+import io.mockk.spyk
+import me.uport.sdk.core.Networks
 import me.uport.sdk.ethrdid.EthrDIDDocument
+import me.uport.sdk.ethrdid.EthrDIDResolver
+import me.uport.sdk.jsonrpc.JsonRPC
 
+/**
+ * This class provides some helper methods that may be used during testing to ease the burden of
+ * mocking EthrDID documents.
+ *
+ *
+ *
+ * **This is usable only during testing.**
+ *
+ *
+ *
+ */
 open class EthrDIDTestHelpers {
 
     companion object {
 
+        /**
+         * Builds the default DID doc for a given eth address.
+         * This is the document that would be resolved for the address if no DID operations are ever performed.
+         *
+         *
+         *
+         * **This is usable only during testing.**
+         *
+         *
+         */
+        @JvmStatic
         fun mockDocForAddress(address: String): EthrDIDDocument {
             val did = "did:ethr:$address"
-            return EthrDIDDocument.fromJson("""
+            return EthrDIDDocument.fromJson(
+                """
             {
               "@context": "https://w3id.org/did/v1",
               "id": "$did",
@@ -21,7 +49,31 @@ open class EthrDIDTestHelpers {
                    "type": "Secp256k1SignatureAuthentication2018",
                    "publicKey": "$did#owner"}]
             }
-        """.trimIndent())
+        """.trimIndent()
+            )
+        }
+
+        /**
+         * Creates a mock EthrDIDResolver that resolves to the default DID document for a particular address
+         * without accessing the network.
+         *
+         * This has to be registered to [UniversalDID] for it to be used during JWT verification.
+         *
+         *
+         *
+         * **This is usable only during testing.**
+         *
+         *
+         *
+         *
+         */
+        @JvmStatic
+        fun getMockResolverForAddress(address: String): EthrDIDResolver {
+            val resolver = spyk(EthrDIDResolver(JsonRPC(Networks.mainnet.rpcUrl)))
+            coEvery {
+                resolver.resolve("did:ethr:$address")
+            } returns mockDocForAddress(address)
+            return resolver
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,5 +3,6 @@ include ':uport-did'
 include ':ethr-did'
 include ':universal-did'
 include ':jwt'
+include ':jwt-java'
 
 include ':jwt-test'


### PR DESCRIPTION
This is a test of a wrapper for `did-jwt` usable in a JAVA 8 app.

This is a java compatible `did-jwt` library built by wrapping the kotlin variant.

in your `build.gradle`:
```groovy
dependencies {
    implementation "com.github.uport-project.kotlin-did-jwt:jwt-java:eb45524e15"
}
```

The wrapper exposes the same signature as the kotlin variant so they are not usable in the same project.
This is not set in stone so if needed, they can be differentiated, because it's likely there need to be different calling conventions for Java (builder pattern since there are no default params).

As opposed to the coroutines of the kotlin variant, the wrapper methods result in `CompletableFuture<*>`  so they are usable in a Java 8 context.


### create a token

```java
HashMap<String, Object> payload = new HashMap<>();
put.put("claim", "something something");

KPSigner signer = new KPSigner("0x65fc670d9351cb87d1f56702fb56a7832ae2aab3427be944ab8c9f2a0ab87960");
String issuer = "did:ethr:" + signer.getAddress();

CompletableFuture<String> jwtFuture = new JWTTools().createJWT(
        payload,
        issuer,
        signer,
        -1,
        JwtHeader.ES256K);

//...sometime later
String jwtToken = jwtFuture.join();
```

### verify a token

```java
JWTTools tools = new JWTTools();
CompletableFuture<JwtPayload> jwtPayloadCompletableFuture =
        tools.verify(
"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNTYxOTcxMTE5LCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.t5o1vzZExArlrrTVHmwtti7fnicXqvWrX6SS3F-Lu3budH7p6zQHjG8X7EvUTRUxhvr-eENCbXeteSE4rgF7MA",
                false,
                null);

//...sometime later
JwtPayload result = jwtPayloadCompletableFuture.join();
```

---
Also, there's a test artifact that can be used to mock some EthrDID doc calls.
`testImplementation "com.github.uport-project.kotlin-did-jwt:jwt-test:eb45524e15"`