### PR TITLE
[Bugfix] ethr-did delegate keys not being resolved

### DIFF
--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDID.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDID.kt
@@ -5,6 +5,7 @@ package me.uport.sdk.ethrdid
 import me.uport.sdk.jsonrpc.JsonRPC
 import me.uport.sdk.signer.Signer
 import me.uport.sdk.signer.signRawTx
+import me.uport.sdk.signer.utf8
 import me.uport.sdk.universaldid.PublicKeyType
 import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.model.Address
@@ -50,7 +51,7 @@ class EthrDID(
 
 
     class DelegateOptions(
-        val delegateType: PublicKeyType = PublicKeyType.Secp256k1VerificationKey2018,
+        val delegateType: PublicKeyType = PublicKeyType.veriKey,
         val expiresIn: Long = 86400L
     )
 
@@ -78,7 +79,7 @@ class EthrDID(
 
         val encodedCall = EthereumDIDRegistry.AddDelegate.encode(
             Solidity.Address(this.address.hexToBigInteger()),
-            Solidity.Bytes32(options.delegateType.name.toByteArray()),
+            Solidity.Bytes32(options.delegateType.name.toByteArray(utf8)),
             Solidity.Address(delegate.hexToBigInteger()),
             Solidity.UInt256(BigInteger.valueOf(options.expiresIn))
         )
@@ -88,13 +89,13 @@ class EthrDID(
 
     suspend fun revokeDelegate(
         delegate: String,
-        delegateType: PublicKeyType = PublicKeyType.Secp256k1VerificationKey2018,
+        delegateType: PublicKeyType = PublicKeyType.veriKey,
         txOptions: TransactionOptions? = null
     ): String {
         val owner = this.lookupOwner()
         val encodedCall = EthereumDIDRegistry.RevokeDelegate.encode(
             Solidity.Address(this.address.hexToBigInteger()),
-            Solidity.Bytes32(delegateType.name.toByteArray()),
+            Solidity.Bytes32(delegateType.name.toByteArray(utf8)),
             Solidity.Address(delegate.hexToBigInteger())
         )
 
@@ -105,8 +106,8 @@ class EthrDID(
         val owner = this.lookupOwner()
         val encodedCall = EthereumDIDRegistry.SetAttribute.encode(
             Solidity.Address(this.address.hexToBigInteger()),
-            Solidity.Bytes32(key.toByteArray()),
-            Solidity.Bytes(value.toByteArray()),
+            Solidity.Bytes32(key.toByteArray(utf8)),
+            Solidity.Bytes(value.toByteArray(utf8)),
             Solidity.UInt256(BigInteger.valueOf(expiresIn))
         )
         return signAndSendContractCall(owner, encodedCall, txOptions)

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -16,6 +16,8 @@ import me.uport.sdk.signer.utf8
 import me.uport.sdk.universaldid.*
 import me.uport.sdk.universaldid.PublicKeyType.Companion.Secp256k1SignatureAuthentication2018
 import me.uport.sdk.universaldid.PublicKeyType.Companion.Secp256k1VerificationKey2018
+import me.uport.sdk.universaldid.PublicKeyType.Companion.sigAuth
+import me.uport.sdk.universaldid.PublicKeyType.Companion.veriKey
 import org.kethereum.encodings.encodeToBase58String
 import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.extensions.toHexStringNoPrefix
@@ -259,13 +261,13 @@ open class EthrDIDResolver(
 
             when (delegateType) {
                 Secp256k1SignatureAuthentication2018.name,
-                sigAuth -> authEntries[key] = AuthenticationEntry(
+                sigAuth.name -> authEntries[key] = AuthenticationEntry(
                     type = Secp256k1SignatureAuthentication2018,
                     publicKey = "$ownerDID#delegate-$delegateIndex"
                 )
 
                 Secp256k1VerificationKey2018.name,
-                veriKey -> pkEntries[key] = PublicKeyEntry(
+                veriKey.name -> pkEntries[key] = PublicKeyEntry(
                     id = "$ownerDID#delegate-$delegateIndex",
                     type = Secp256k1VerificationKey2018,
                     owner = ownerDID,
@@ -279,16 +281,13 @@ open class EthrDIDResolver(
     companion object {
         const val DEFAULT_REGISTRY_ADDRESS = "0xdca7ef03e98e0dc2b855be647c39abe984fcf21b"
 
-        internal const val veriKey = "veriKey"
-        internal const val sigAuth = "sigAuth"
-
         private val attrTypes = mapOf(
-            sigAuth to "SignatureAuthentication2018",
-            veriKey to "VerificationKey2018"
+            sigAuth.name to "SignatureAuthentication2018",
+            veriKey.name to "VerificationKey2018"
         )
 
         private fun parseType(algo: String, rawType: String): PublicKeyType {
-            var type = if (rawType.isBlank()) veriKey else rawType
+            var type = if (rawType.isBlank()) veriKey.name else rawType
             type = attrTypes[type] ?: type
             return PublicKeyType("$algo$type") //will throw exception if none found
         }

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -89,7 +89,7 @@ open class EthrDIDResolver(
      */
     @Suppress("TooGenericExceptionCaught")
     internal suspend fun getHistory(identity: String): List<Any> {
-        val lastChangedQueue: Queue<BigInteger> = PriorityQueue<BigInteger>()
+        val lastChangedQueue: Queue<BigInteger> = PriorityQueue()
         val events = emptyList<Any>().toMutableList()
         lastChangedQueue.add(lastChanged(identity).hexToBigInteger())
         do {
@@ -249,7 +249,7 @@ open class EthrDIDResolver(
         val authEntries = mapOf<String, AuthenticationEntry>().toMutableMap()
 
         var delegateIndex = delegateCount
-        val delegateType = event.delegatetype.bytes.toString(utf8)
+        val delegateType = event.delegatetype.bytes.toString(utf8).replace("\u0000","")
         val delegate = event.delegate.value.toHexStringNoPrefix().prepend0xPrefix()
         val key = "DIDDelegateChanged-$delegateType-$delegate"
         val validTo = event.validto.value.toLong()

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -184,13 +184,13 @@ class EthrDIDResolverTest {
 
         coEvery {
             //mock the lookup owner call to return itself
-            rpc.ethCall(any(), eq("0x8733d4e8000000000000000000000000cf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed"))
-        }.returns("0x000000000000000000000000cf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
+            rpc.ethCall(any(), eq("0x8733d4e800000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656"))
+        }.returns("0x00000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656")
 
         coEvery {
-            //mock the lastChanged call to point to block number 4513151 (0x44dd7f)
-            rpc.ethCall(any(), eq("0xf96d0f9f000000000000000000000000cf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed"))
-        }.returns("0x000000000000000000000000000000000000000000000000000000000044dd7f")
+            //mock the lastChanged call to point to block number 4680310 (0x476A76)
+            rpc.ethCall(any(), eq("0xf96d0f9f00000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656"))
+        }.returns("0x0000000000000000000000000000000000000000000000000000000000476A76")
 
         coEvery {
             rpc.getLogs(address = any(), topics = any(), fromBlock = any(), toBlock = any())
@@ -200,15 +200,15 @@ class EthrDIDResolverTest {
                     address = "0xdca7ef03e98e0dc2b855be647c39abe984fcf21b",
                     topics = listOf(
                         "0x5a5084339536bcab65f20799fcc58724588145ca054bd2be626174b27ba156f7",
-                        "0x000000000000000000000000cf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed"
+                        "0x00000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656"
                     ),
                     //this is the important bit that states that a delegate key was added
-                    data = "0x536563703235366b31566572696669636174696f6e4b6579323031380000000000000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e265600000000000000000000000000000000000000000000000000000000621f6e260000000000000000000000000000000000000000000000000000000000000000",
-                    blockNumber = BigInteger("4513151"),
-                    transactionHash = "0x16f847d99c47b90f34c494588a31874dc2da081b00ff34968a86d6f7d15863af",
-                    transactionIndex = BigInteger("8"),
-                    blockHash = "0xa237598ed026c2872ed8272a02d9fe8174a64b5bef9286cb37190a854fec3706",
-                    logIndex = BigInteger("8"),
+                    data = "0x766572694b657900000000000000000000000000000000000000000000000000000000000000000000000000cf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed000000000000000000000000000000000000000000000000000000006245b1050000000000000000000000000000000000000000000000000000000000000000",
+                    blockNumber = BigInteger("4680310"),
+                    transactionHash = "0x5b1749dd1eb4cee09f114e5b12d82d68c9099ba38482d602f2d939f9082f71e3",
+                    transactionIndex = BigInteger("0"),
+                    blockHash = "0x4f1acf82e4b2578cb5a5c0fe1c3806dc89d5b28ca4946219cf1a0f04ad654fb8",
+                    logIndex = BigInteger("0"),
                     removed = false
                 )
             ),
@@ -216,34 +216,35 @@ class EthrDIDResolverTest {
         )
 
         val resolver = EthrDIDResolver(rpc)
-        val ddo = resolver.resolve("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
+        val ddo = resolver.resolve("0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656")
 
         val expectedDDO = EthrDIDDocument.fromJson(
             //language=json
             """{
-          "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-          "publicKey": [
-            {
-              "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
-              "type": "Secp256k1VerificationKey2018",
-              "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-              "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed"
-            },
-            {
-              "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#delegate-1",
-              "type": "Secp256k1VerificationKey2018",
-              "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-              "ethereumAddress": "0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656"
-            }
-          ],
-          "authentication": [
-            {
-              "type": "Secp256k1SignatureAuthentication2018",
-              "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
-            }
-          ]
-        }
-        """.trimIndent()
+              "id": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656",
+              "publicKey": [
+                {
+                  "id": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656#owner",
+                  "type": "Secp256k1VerificationKey2018",
+                  "owner": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656",
+                  "ethereumAddress": "0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656"
+                },
+                {
+                  "id": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656#delegate-1",
+                  "type": "Secp256k1VerificationKey2018",
+                  "owner": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656",
+                  "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed"
+                }
+              ],
+              "authentication": [
+                {
+                  "type": "Secp256k1SignatureAuthentication2018",
+                  "publicKey": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656#owner"
+                }
+              ],
+              "service": [],
+              "@context": "https://w3id.org/did/v1"
+            }""".trimIndent()
         )
 
         assertThat(ddo).isEqualTo(expectedDDO)

--- a/universal-did/src/main/java/me/uport/sdk/universaldid/DIDDocument.kt
+++ b/universal-did/src/main/java/me/uport/sdk/universaldid/DIDDocument.kt
@@ -56,7 +56,7 @@ data class ServiceEntry(
 
 /**
  * This is a wrapper class for PublicKeyType
- * It is meant to provide a more typesafe way of dealing with these strings.
+ * It is meant to provide a more type-safe way of dealing with these strings.
  * This will be ported to inline classes when that feature of kotlin stabilizes and works properly with serialization
  *
  * see DID Document spec:
@@ -91,7 +91,6 @@ data class PublicKeyType(val name: String) {
          */
         val Secp256k1SignatureAuthentication2018 = PublicKeyType("Secp256k1SignatureAuthentication2018")
 
-
         /**
          * While not directly generated here, it is treated as [Secp256k1VerificationKey2018]
          */
@@ -106,5 +105,19 @@ data class PublicKeyType(val name: String) {
          * encryption key. Usage described here: https://github.com/uport-project/specs/blob/develop/pki/diddocument.md
          */
         val Curve25519EncryptionPublicKey = PublicKeyType("Curve25519EncryptionPublicKey")
+
+        /**
+         * Used in ethr-did events to signal the existence of a [Secp256k1VerificationKey2018]
+         * in the DID document.
+         * Using a shorter key name reduces gas cost in DID operations.
+         */
+        val veriKey = PublicKeyType("veriKey")
+
+        /**
+         * Used in ethr-did events to signal the existence of a [Secp256k1SignatureAuthentication2018]
+         * in the DID document.
+         * Using a shorter key name reduces gas cost in DID operations.
+         */
+        val sigAuth = PublicKeyType("sigAuth")
     }
 }


### PR DESCRIPTION
This should be merged only after #7 

### What's here
The delegate keys of an `ethr-did` were not showing up in the resolved DID document.

This was caused by a broken conversion of a `ByteArray` into a `String`, resulting in a string with a bunch of `null` characters at the end.
When the event log was parsed to accumulate the publicKey entries, the respective strings would fail basic string comparison with the expected values, resulting in all delegate keys getting skipped.

### Testing

I added a test to validate the bug in a controlled environment.
Running `./gradlew test` will also run that test. This is already done by CI.

Also, the same data can be validated in the wild, on the rinkeby network:
##### prerequisites:
```kotlin
val resolver = EthrDIDResolver(
    rpc = JsonRPC(Networks.rinkeby.rpcUrl),
    registryAddress = Networks.rinkeby.ethrDidRegistry
)
val ddo = resolver.resolve("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
println(ddo.toJson())
```
##### Expected output:
it should resolve to the following document:
```json
{
  "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
  "publicKey": [{
      "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
      "type": "Secp256k1VerificationKey2018",
      "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
      "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed"
    },
    {
      "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#delegate-1",
      "type": "Secp256k1VerificationKey2018",
      "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
      "ethereumAddress": "0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656"
    }],
  "authentication": [{
      "type": "Secp256k1SignatureAuthentication2018",
      "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
    }],
  "service": [],
  "@context": "https://w3id.org/did/v1"
}
```

##### Previous output (broken)

```json
{
  "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
  "publicKey": [{
      "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
      "type": "Secp256k1VerificationKey2018",
      "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
      "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed"
    }],
  "authentication": [{
      "type": "Secp256k1SignatureAuthentication2018",
      "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
    }],
  "service": [],
  "@context": "https://w3id.org/did/v1"
}
```


### Note

This PR also includes some additions to the EthrDID contract interface that allow the user to override some default transaction parameters (like nonce, value, gas, gasPrice) before signing.
This interface is not documented and probably not used externally yet.
This change does not impact functionality since the previous defaults still get used if the options are `null`.