### PR TITLE
[Feature] remove `iat` when explicitly set to `null`

### DIFF
--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -130,7 +130,11 @@ class JWTTools(
         val header = JwtHeader(alg = algorithm)
 
         val iatSeconds = floor(timeProvider.nowMs() / 1000.0).toLong()
-        mutablePayload["iat"] = payload["iat"] ?: iatSeconds
+        if (payload.containsKey("iat") && payload["iat"] == null) {
+            mutablePayload.remove("iat")
+        } else {
+            mutablePayload["iat"] = payload["iat"] ?: iatSeconds
+        }
 
         val expSeconds = iatSeconds + expiresInSeconds
         if (expiresInSeconds >= 0) {

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -1,10 +1,7 @@
 package me.uport.sdk.jwt
 
 import assertk.assertThat
-import assertk.assertions.isEqualTo
-import assertk.assertions.isFalse
-import assertk.assertions.isInstanceOf
-import assertk.assertions.isNotNull
+import assertk.assertions.*
 import io.mockk.coEvery
 import io.mockk.mockkObject
 import io.mockk.spyk
@@ -532,13 +529,32 @@ class JWTToolsJVMTest {
         val tested = JWTTools()
 
         val payload = mapOf("iat" to null)
-        val signer = KPSigner("0x1234")
-        val issuerDID = "did:ethr:${signer.getAddress()}"
 
-        val jwt = tested.createJWT(payload, issuerDID, signer)
+        val jwt = tested.createJWT(payload, "did:ex:ex", KPSigner("0x1234"))
 
         val (_, decoded, _) = tested.decodeRaw(jwt)
         assertThat(decoded.containsKey("iat")).isFalse()
+    }
+
+    @Test
+    fun `iat set by default when not specified`() = runBlocking {
+        val tested = JWTTools()
+
+        val jwt = tested.createJWT(emptyMap(), "did:ex:ex", KPSigner("0x1234"))
+
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded.containsKey("iat")).isTrue()
+    }
+
+    @Test
+    fun `default iat is overridden by payload`() = runBlocking {
+        val tested = JWTTools()
+
+        val payload = mapOf("iat" to 5678L)
+        val jwt = tested.createJWT(payload, "did:ex:ex", KPSigner("0x1234"))
+
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded["iat"]).isEqualTo(5678L)
     }
 }
 

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -526,6 +526,20 @@ class JWTToolsJVMTest {
         val (_, decoded, _) = tested.decodeRaw(jwt)
         assertThat(decoded.containsKey("exp")).isFalse()
     }
+
+    @Test
+    fun `removes iat when explicitly set as null`() = runBlocking {
+        val tested = JWTTools()
+
+        val payload = mapOf("iat" to null)
+        val signer = KPSigner("0x1234")
+        val issuerDID = "did:ethr:${signer.getAddress()}"
+
+        val jwt = tested.createJWT(payload, issuerDID, signer)
+
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded.containsKey("iat")).isFalse()
+    }
 }
 
 


### PR DESCRIPTION
### What's here

The `iat` field is not a mandatory field in JWTs and in some cases (like the new w3c VC spec) it is not mentioned at all so it is essentially bloatware, also complicating the verification.
This PR should unblock the discussion in this PR (https://github.com/uport-project/uport-android-sdk/pull/100#discussion_r307305945)

### Acceptance

When calling `createJWT` with a payload that has the `iat` field set to `null`, the resulting JWT payload does not contain an `iat` field.
Otherwise it either sets it to the current timestamp or picks it up from the payload.

### Testing

Tests were added to cover all 3 paths. `./gradlew test` runs the entire suite, including the new ones.