### PR TITLE
[Feature] allow issuer to be overridden by payload when creating JWTs

### DIFF
--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -146,7 +146,13 @@ class JWTTools(
             mutablePayload.remove("exp")
         }
 
-        mutablePayload["iss"] = issuerDID
+        if (payload.containsKey("iss") && payload["iss"] == null) {
+            mutablePayload.remove("iss")
+        } else if (payload.containsKey("iss")) {
+            mutablePayload["iss"] = payload["iss"]
+        } else {
+            mutablePayload["iss"] = issuerDID
+        }
 
         val serializedPayload = Json(JsonConfiguration.Stable)
             .stringify(ArbitraryMapSerializer, mutablePayload)

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -556,6 +556,38 @@ class JWTToolsJVMTest {
         val (_, decoded, _) = tested.decodeRaw(jwt)
         assertThat(decoded["iat"]).isEqualTo(5678L)
     }
+
+    @Test
+    fun `default iss is overridden by payload`() = runBlocking {
+        val tested = JWTTools()
+
+        val payload = mapOf("iss" to "example.issuer")
+        val jwt = tested.createJWT(payload, "did:ex:ex", KPSigner("0x1234"))
+
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded["iss"]).isEqualTo("example.issuer")
+    }
+
+    @Test
+    fun `default iss is removed by payload`() = runBlocking {
+        val tested = JWTTools()
+
+        val payload = mapOf("iss" to null)
+        val jwt = tested.createJWT(payload, "did:ex:ex", KPSigner("0x1234"))
+
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded.containsKey("iss")).isFalse()
+    }
+
+    @Test
+    fun `iss is set by default`() = runBlocking {
+        val tested = JWTTools()
+
+        val jwt = tested.createJWT(emptyMap(), "did:ex:ex", KPSigner("0x1234"))
+
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded["iss"]).isEqualTo("did:ex:ex")
+    }
 }
 
 


### PR DESCRIPTION
### what's here

Using this changeset the developer can override the issuer field of a JWT when calling `createJWT` by passing in a `null` or different issuer in the `payload` parameter.

This is not meant to be a publicly usable method of setting an issuer but it's required by the w3c verifiable credential compliance tests.

This doesn't change any existing API, but only brings more clarity to an existing edge-case.

### testing

Tests were added to cover all the known paths an `iss` field can take, from parameter to encoded JWT, including previously uncovered edge cases.