### PR TITLE
[Feature] multi network ethr did

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         kmnid_version = "0.3.2"
         kethereum_version = "0.75.1"
         spongycastle_version = "1.58.0.0"
-        uport_kotlin_common_version = "0e122c74ec445c254ddae9399292c6e853ac8ae9"
+        uport_kotlin_common_version = "0.1.1"
 
         current_release_version = "0.3.1"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         kmnid_version = "0.3.2"
         kethereum_version = "0.75.1"
         spongycastle_version = "1.58.0.0"
-        uport_kotlin_common_version = "0.1.1"
+        uport_kotlin_common_version = "0e122c74ec445c254ddae9399292c6e853ac8ae9"
 
         current_release_version = "0.3.1"
     }

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDNetwork.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDNetwork.kt
@@ -12,7 +12,7 @@ import me.uport.sdk.jsonrpc.JsonRPC
  *
  * Please see https://github.com/uport-project/ethr-did-registry#contract-deployments for the known registry addresses.
  */
-class EthrDIDNetwork(
+class EthrDIDNetwork (
     /**
      * name of the ethereum network (ex: "mainnet", "rinkeby")
      */

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDNetwork.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDNetwork.kt
@@ -38,7 +38,7 @@ class EthrDIDNetwork (
 )
 
 /**
- * converts
+ * converts a network description to an [EthrDIDNetwork] instance
  */
 fun EthNetwork.toEthrDIDNetwork() =
     EthrDIDNetwork(

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDNetwork.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDNetwork.kt
@@ -1,0 +1,49 @@
+package me.uport.sdk.ethrdid
+
+import me.uport.sdk.core.EthNetwork
+import me.uport.sdk.jsonrpc.JsonRPC
+
+/**
+ * Encapsulates the configuration necessary to resolve an ethr-did (ERC1056)
+ *
+ * You can specify multiple of these configurations to an [EthrDIDResolver.Builder] to allow it to resolve ethr-DIDs
+ * anchored in the respective networks.
+ * example: `did:ethr:rinkeby:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed`
+ *
+ * Please see https://github.com/uport-project/ethr-did-registry#contract-deployments for the known registry addresses.
+ */
+class EthrDIDNetwork(
+    /**
+     * name of the ethereum network (ex: "mainnet", "rinkeby")
+     */
+    val name: String,
+
+    /**
+     * address of the ERC1056 contract.
+     * The default for the more popular networks is "0xdca7ef03e98e0dc2b855be647c39abe984fcf21b"
+     */
+    val registryAddress: String,
+
+    /**
+     * A JsonRPC instance
+     *
+     * for example JsonRPC("https://rinkeby.infura.io/v3/<your infura api key>")
+     */
+    val rpc: JsonRPC,
+
+    /**
+     * The chain ID (see EIP-155 https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md)
+     */
+    val chainId: String? = null
+)
+
+/**
+ * converts
+ */
+fun EthNetwork.toEthrDIDNetwork() =
+    EthrDIDNetwork(
+        name = name,
+        chainId = networkId,
+        registryAddress = ethrDidRegistry,
+        rpc = JsonRPC(rpcUrl)
+    )

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -48,7 +48,8 @@ open class EthrDIDResolver : DIDResolver {
 
     @Deprecated(
         "Constructing the resolver directly has been deprecated " +
-                "in favor of the Builder pattern that can supply multi-network configurations.",
+                "in favor of the Builder pattern that can supply multi-network configurations." +
+                "This will be removed in the next major release.",
         ReplaceWith(
             """EthrDIDResolver.Builder().addNetwork(EthrDIDNetwork("", registryAddress, rpc, "0x1")).build()""",
             "me.uport.sdk.ethrdid.EthrDIDResolver.Companion.DEFAULT_REGISTRY_ADDRESS"
@@ -123,7 +124,7 @@ open class EthrDIDResolver : DIDResolver {
             if (this.isBlank()) DEFAULT_NETWORK_NAME else this
         }
 
-        val didNetworkConfig = try {
+        val ethNetworkConfig = try {
             _registryMap[networkIdentifier]
         } catch (e: IllegalArgumentException) {
             throw IllegalArgumentException(
@@ -133,8 +134,8 @@ open class EthrDIDResolver : DIDResolver {
             )
         }
 
-        val rpc = didNetworkConfig.rpc
-        val registryAddress = didNetworkConfig.registryAddress
+        val rpc = ethNetworkConfig.rpc
+        val registryAddress = ethNetworkConfig.registryAddress
 
         val normalizedDid = normalizeDid(did)
         val identity = extractAddress(normalizedDid)

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -251,7 +251,7 @@ open class EthrDIDResolver(
         val authEntries = mapOf<String, AuthenticationEntry>().toMutableMap()
 
         var delegateIndex = delegateCount
-        val delegateType = event.delegatetype.bytes.toString(utf8).replace("\u0000","")
+        val delegateType = event.delegatetype.bytes.toString(utf8).replace("\u0000", "")
         val delegate = event.delegate.value.toHexStringNoPrefix().prepend0xPrefix()
         val key = "DIDDelegateChanged-$delegateType-$delegate"
         val validTo = event.validto.value.toLong()
@@ -296,7 +296,7 @@ open class EthrDIDResolver(
         private val identityExtractPattern = "^did:ethr:(0x[0-9a-fA-F]{40})".toRegex()
 
         //language=RegExp
-        private val didParsePattern = "^(did:)?((\\w+):)?((0x)([0-9a-fA-F]{40}))".toRegex()
+        private val didParsePattern = "^(did:)?((\\w+):)?((\\w+):)?((0x)([0-9a-fA-F]{40}))".toRegex()
 
         private fun parseIdentity(normalizedDid: String) = identityExtractPattern
             .find(normalizedDid)
@@ -304,7 +304,7 @@ open class EthrDIDResolver(
 
         internal fun normalizeDid(did: String): String {
             val matchResult = didParsePattern.find(did) ?: return ""
-            val (didHeader, _, didType, _, _, hexDigits) = matchResult.destructured
+            val (didHeader, _, didType, _, network, _, _, hexDigits) = matchResult.destructured
             if (didType.isNotBlank() && didType != "ethr") {
                 //should forward to another resolver
                 return ""

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -293,11 +293,11 @@ open class EthrDIDResolver(
         }
 
         //language=RegExp
-        private val identityExtractPattern = "^did:ethr:(0x[0-9a-fA-F]{40})".toRegex()
+        private val identityExtractPattern = "^did:ethr:((\\w+):)?(0x[0-9a-fA-F]{40})".toRegex()
 
         internal fun extractAddress(normalizedDid: String) = identityExtractPattern
             .find(normalizedDid)
-            ?.destructured?.component1() ?: ""
+            ?.destructured?.component3() ?: ""
 
         //language=RegExp
         private val didParsePattern = "^(did:)?((\\w+):)?((\\w+):)?((0x)([0-9a-fA-F]{40}))".toRegex()

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -93,8 +93,17 @@ open class EthrDIDResolver : DIDResolver {
         }
 
         companion object {
+
             private fun buildRegistryMap(networkConfigs: MutableList<EthrDIDNetwork>) = RegistryMap().apply {
+                //register given networks
                 networkConfigs.forEach { registerNetwork(it) }
+                //if no default was provided, try to copy mainnet
+                (getOrNull("") ?: getOrNull("mainnet") ?: getOrNull("0x1"))
+                    ?.let {
+                        registerNetwork(
+                            EthrDIDNetwork("", it.registryAddress, it.rpc, it.chainId)
+                        )
+                    }
             }
         }
     }

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -58,7 +58,7 @@ open class EthrDIDResolver(
         }
 
         val normalizedDid = normalizeDid(did)
-        val identity = parseIdentity(normalizedDid)
+        val identity = extractAddress(normalizedDid)
         val ethrdidContract = EthrDID(identity, rpc, registryAddress, Signer.blank)
         val owner = ethrdidContract.lookupOwner(false)
         val history = getHistory(identity)
@@ -295,12 +295,12 @@ open class EthrDIDResolver(
         //language=RegExp
         private val identityExtractPattern = "^did:ethr:(0x[0-9a-fA-F]{40})".toRegex()
 
-        //language=RegExp
-        private val didParsePattern = "^(did:)?((\\w+):)?((\\w+):)?((0x)([0-9a-fA-F]{40}))".toRegex()
-
-        private fun parseIdentity(normalizedDid: String) = identityExtractPattern
+        internal fun extractAddress(normalizedDid: String) = identityExtractPattern
             .find(normalizedDid)
             ?.destructured?.component1() ?: ""
+
+        //language=RegExp
+        private val didParsePattern = "^(did:)?((\\w+):)?((\\w+):)?((0x)([0-9a-fA-F]{40}))".toRegex()
 
         internal fun normalizeDid(did: String): String {
             val matchResult = didParsePattern.find(did) ?: return ""

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -295,16 +295,20 @@ open class EthrDIDResolver(
         //language=RegExp
         private val identityExtractPattern = "^did:ethr:((\\w+):)?(0x[0-9a-fA-F]{40})".toRegex()
 
-        internal fun extractAddress(normalizedDid: String) = identityExtractPattern
+        internal fun extractAddress(normalizedDid: String): String = identityExtractPattern
             .find(normalizedDid)
             ?.destructured?.component3() ?: ""
+
+        internal fun extractNetwork(normalizedDid: String): String = identityExtractPattern
+            .find(normalizedDid)
+            ?.destructured?.component2() ?: ""
 
         //language=RegExp
         private val didParsePattern = "^(did:)?((\\w+):)?((\\w+):)?((0x)([0-9a-fA-F]{40}))".toRegex()
 
         internal fun normalizeDid(did: String): String {
             val matchResult = didParsePattern.find(did) ?: return ""
-            val (didHeader, _, didType, _, network, _, _, hexDigits) = matchResult.destructured
+            val (didHeader, _, didType, _, _, _, _, hexDigits) = matchResult.destructured
             if (didType.isNotBlank() && didType != "ethr") {
                 //should forward to another resolver
                 return ""

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/RegistryMap.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/RegistryMap.kt
@@ -1,0 +1,32 @@
+package me.uport.sdk.ethrdid
+
+import org.walleth.khex.clean0xPrefix
+import org.walleth.khex.prepend0xPrefix
+
+/**
+ * This encapsulates a mapping of names and chainIDs to [EthrDIDNetwork] configuration instances
+ */
+internal class RegistryMap {
+
+    private val _regMap = mutableMapOf<String, EthrDIDNetwork>()
+
+    fun registerNetwork(networkConfig: EthrDIDNetwork): RegistryMap {
+        _regMap[networkConfig.name] = networkConfig
+        if (networkConfig.chainId != null) {
+            _regMap[normalizeQuantity(networkConfig.chainId)] = networkConfig
+        }
+        return this
+    }
+
+    operator fun get(query: String): EthrDIDNetwork {
+        val cleanNetId = normalizeQuantity(query)
+        return _regMap[cleanNetId]
+            ?: _regMap[query]
+            ?: throw IllegalArgumentException("No known configuration for the `[$query]` ethereum network")
+
+    }
+
+    companion object {
+        private fun normalizeQuantity(id: String) = id.clean0xPrefix().trimStart('0').prepend0xPrefix()
+    }
+}

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/RegistryMap.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/RegistryMap.kt
@@ -26,6 +26,12 @@ internal class RegistryMap {
 
     }
 
+    fun getOrNull(query: String): EthrDIDNetwork? = try {
+        this[query]
+    } catch (ex: IllegalArgumentException) {
+        null
+    }
+
     companion object {
         private fun normalizeQuantity(id: String) = id.clean0xPrefix().trimStart('0').prepend0xPrefix()
     }

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/RegistryMap.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/RegistryMap.kt
@@ -33,6 +33,25 @@ internal class RegistryMap {
     }
 
     companion object {
+
         private fun normalizeQuantity(id: String) = id.clean0xPrefix().trimStart('0').prepend0xPrefix()
+
+        /**
+         * build a usable registry map from a list of network configurations.
+         * In case it is not defined in the list, this method also tries to define
+         * a default network based on any network resembling `mainnet`
+         */
+        fun fromNetworks(networkConfigs: MutableList<EthrDIDNetwork>) = RegistryMap().apply {
+            //register given networks
+            networkConfigs.forEach { registerNetwork(it) }
+            //if no default was provided, try to copy mainnet
+            (getOrNull("") ?: getOrNull("mainnet") ?: getOrNull("0x1"))
+                ?.let {
+                    registerNetwork(
+                        EthrDIDNetwork("", it.registryAddress, it.rpc, it.chainId)
+                    )
+                }
+        }
     }
 }
+

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -478,7 +478,7 @@ class EthrDIDResolverTest {
         )
         validNetworkedDIDs.forEach { (did, expectedNetwork) ->
             val extractedNetwork = EthrDIDResolver.extractNetwork(did).toLowerCase()
-            println("extracting address from `$did` got `$extractedNetwork`")
+            println("extracting network from `$did` got `$extractedNetwork`")
             assertThat(extractedNetwork).isEqualTo(expectedNetwork)
         }
     }

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -17,6 +17,7 @@ import me.uport.sdk.jsonrpc.JsonRpcLogItem
 import me.uport.sdk.jwt.test.EthrDIDTestHelpers
 import me.uport.sdk.signer.hexToBytes32
 import me.uport.sdk.signer.utf8
+import me.uport.sdk.testhelpers.coAssert
 import org.junit.Test
 import org.kethereum.extensions.hexToBigInteger
 import pm.gnosis.model.Solidity
@@ -74,7 +75,6 @@ class EthrDIDResolverTest {
         val http = mockk<HttpClient>()
         val rpc = JsonRPC("", http)
         val realAddress = "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
-//        val resolver = EthrDIDResolver(rpc)
         val lastChanged = "0x00000000000000000000000000000000000000000000000000000000002a8a7d".hexToBigInteger()
 
         //language=json
@@ -475,4 +475,133 @@ class EthrDIDResolverTest {
             assertThat(extractedNetwork).isEqualTo(expectedNetwork)
         }
     }
+
+    @Test
+    fun `can resolve generic did when only provided with mainnet config`() {
+        val http = mockk<HttpClient>()
+        val referenceDDO = EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
+
+        val addressHex = "b9c5714089478a327f09197987f16f9e5d936e8a"
+
+        val rpc = spyk(JsonRPC("mainnetRPC", http))
+        //canned response for get owner query
+        coEvery {
+            rpc.ethCall(
+                any(),
+                eq("0x8733d4e8000000000000000000000000$addressHex")
+            )
+        } returns "0x000000000000000000000000$addressHex"
+        //canned response for last changed query
+        coEvery {
+            rpc.ethCall(
+                any(),
+                eq("0xf96d0f9f000000000000000000000000$addressHex")
+            )
+        } returns "0x0000000000000000000000000000000000000000000000000000000000000000"
+        //canned response for getLogs
+        coEvery { http.urlPost(eq("mainnetRPC"), any(), any()) } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
+
+
+        val resolver = EthrDIDResolver.Builder()
+            .addNetwork(EthrDIDNetwork("mainnet", "mockregistry", rpc, "0x1"))
+            .build()
+
+        coAssert {
+            val ddo = resolver.resolve("did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+            assertThat(ddo).isEqualTo(referenceDDO)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `can resolve networked dids`() = runBlocking {
+        val http = mockk<HttpClient>()
+        val referenceDDO = EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
+
+        val addressHex = "b9c5714089478a327f09197987f16f9e5d936e8a"
+
+        val rpc = spyk(JsonRPC("mainnetRPC", http))
+        //canned response for get owner query
+        coEvery {
+            rpc.ethCall(
+                any(),
+                eq("0x8733d4e8000000000000000000000000$addressHex")
+            )
+        } returns "0x000000000000000000000000$addressHex"
+        //canned response for last changed query
+        coEvery {
+            rpc.ethCall(
+                any(),
+                eq("0xf96d0f9f000000000000000000000000$addressHex")
+            )
+        } returns "0x0000000000000000000000000000000000000000000000000000000000000000"
+        //canned response for getLogs
+        coEvery { http.urlPost(any(), any(), any()) } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
+
+
+        val resolver = EthrDIDResolver.Builder()
+            .addNetwork(EthrDIDNetwork("mainnet", "0xregistry", rpc, "0x1"))
+            .addNetwork(EthrDIDNetwork("rinkeby", "0xregistry", rpc, "0x4"))
+            .build()
+
+        val genericDDO = resolver.resolve("did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val mainnetDDO = resolver.resolve("did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val mainnetDDO0x1 = resolver.resolve("did:ethr:0x1:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val rinkebyDDO = resolver.resolve("did:ethr:rinkeby:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val rinkebyDDO0x04 = resolver.resolve("did:ethr:0x04:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+
+        assertThat(genericDDO).isEqualTo(referenceDDO)
+        assertThat(mainnetDDO).isEqualTo(referenceDDO)
+        assertThat(mainnetDDO0x1).isEqualTo(referenceDDO)
+        assertThat(rinkebyDDO).isEqualTo(referenceDDO)
+        assertThat(rinkebyDDO0x04).isEqualTo(referenceDDO)
+    }
+
+    @Test
+    fun `can resolve generic did when only provided with 0x1 config`() {
+        val http = mockk<HttpClient>()
+        val referenceDDO = EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
+
+        val addressHex = "b9c5714089478a327f09197987f16f9e5d936e8a"
+
+        val rpc = spyk(JsonRPC("mainnetRPC", http))
+        //canned response for get owner query
+        coEvery {
+            rpc.ethCall(
+                eq("0xregistry"),
+                eq("0x8733d4e8000000000000000000000000$addressHex")
+            )
+        } returns "0x000000000000000000000000$addressHex"
+        //canned response for last changed query
+        coEvery {
+            rpc.ethCall(
+                eq("0xregistry"),
+                eq("0xf96d0f9f000000000000000000000000$addressHex")
+            )
+        } returns "0x0000000000000000000000000000000000000000000000000000000000000000"
+        //canned response for getLogs
+        coEvery { http.urlPost(eq("mainnetRPC"), any(), any()) } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
+
+
+        val resolver = EthrDIDResolver.Builder()
+            .addNetwork(EthrDIDNetwork("__default__", "0xregistry", rpc, "0x01"))
+            .build()
+
+        coAssert {
+            val ddo = resolver.resolve("did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+            assertThat(ddo).isEqualTo(referenceDDO)
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `throws when missing config`() {
+        val resolver = EthrDIDResolver.Builder().build()
+
+        coAssert {
+            resolver.resolve("did:ethr:unknown:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        }.thrownError {
+            isInstanceOf(IllegalArgumentException::class)
+            hasMessage("Missing registry configuration for `unknown`. To resolve did:ethr:unknown:0x... you need to register an `EthrDIDNetwork` in the EthrDIDResolver.Builder")
+        }
+    }
+
 }

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -38,7 +38,10 @@ class EthrDIDResolverTest {
         } returns "0x0000000000000000000000000000000000000000000000000000000000000000"
 
         val imaginaryAddress = "0x1234"
-        val lastChanged = EthrDIDResolver(rpc).lastChanged(imaginaryAddress, rpc, "0xregistry")
+        val lastChanged = EthrDIDResolver.Builder()
+            .addNetwork(EthrDIDNetwork("", "0xregistry", rpc))
+            .build()
+            .lastChanged(imaginaryAddress, rpc, "0xregistry")
 
         assertThat(encodedCallSlot.captured).isEqualTo("0xf96d0f9f0000000000000000000000000000000000000000000000000000000000001234")
         assertThat(lastChanged.hexToBigInteger()).isEqualTo(BigInteger.ZERO)
@@ -56,7 +59,10 @@ class EthrDIDResolverTest {
         } returns "0x00000000000000000000000000000000000000000000000000000000002a8a7d"
 
         val realAddress = "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
-        val lastChanged = EthrDIDResolver(rpc).lastChanged(realAddress, rpc, "0xregistry")
+        val lastChanged = EthrDIDResolver.Builder()
+            .addNetwork(EthrDIDNetwork("", "0xregistry", rpc))
+            .build()
+            .lastChanged(realAddress, rpc, "0xregistry")
 
         assertThat(encodedCallSlot.captured).isEqualTo("0xf96d0f9f000000000000000000000000f3beac30c498d9e26865f34fcaa57dbb935b0d74")
         assertThat(lastChanged.hexToBigInteger()).isNotEqualTo(BigInteger.ZERO)
@@ -171,7 +177,9 @@ class EthrDIDResolverTest {
         )
         coEvery { rpc.getLogs(any(), any(), any(), any()) }.returnsMany(cannedResponses)
 
-        val resolver = EthrDIDResolver(rpc)
+        val resolver = EthrDIDResolver.Builder()
+            .addNetwork(EthrDIDNetwork("", "0xregistry", rpc))
+            .build()
         val events = resolver.getHistory(realAddress, rpc, "0xregistry")
         assertThat(events).hasSize(3)
     }
@@ -214,7 +222,9 @@ class EthrDIDResolverTest {
             emptyList()
         )
 
-        val resolver = EthrDIDResolver(rpc)
+        val resolver = EthrDIDResolver.Builder()
+            .addNetwork(EthrDIDNetwork("", "0xregistry", rpc))
+            .build()
         val ddo = resolver.resolve("0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656")
 
         val expectedDDO = EthrDIDDocument.fromJson(
@@ -307,7 +317,10 @@ class EthrDIDResolverTest {
         val rpc = JsonRPC("")
 
         assertThat {
-            EthrDIDResolver(rpc).wrapDidDocument("did:ethr:$identity", owner, listOf(event))
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", rpc))
+                .build()
+                .wrapDidDocument("did:ethr:$identity", owner, listOf(event))
         }.doesNotThrowAnyException()
     }
 
@@ -345,7 +358,10 @@ class EthrDIDResolverTest {
         //canned response for getLogs
         coEvery { http.urlPost(any(), any(), any()) } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
 
-        val resolver = EthrDIDResolver(rpc)
+        val resolver =
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", rpc))
+                .build()
         val ddo = resolver.resolve("did:ethr:0x$addressHex")
         assertThat(ddo).isEqualTo(referenceDDO)
     }

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -362,6 +362,7 @@ class EthrDIDResolverTest {
             "did:ethr:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner"
         )
 
+
         val invalidDids = listOf(
             "0xb9c5714089478a327f09197987f16f9e5d936e",
             "B9C5714089478a327F09197987f16f9E5d936E8a",
@@ -381,4 +382,30 @@ class EthrDIDResolverTest {
         }
     }
 
+    @Test
+    fun `can normalize networked DIDs`() {
+        val validNetworkedDIDs = listOf(
+            "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+            "did:ethr:0xB9C5714089478a327F09197987f16f9E5d936E8a",
+            "did:ethr:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner",
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+            "did:ethr:mainnet:0xB9C5714089478a327F09197987f16f9E5d936E8a",
+            "did:ethr:mainnet:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner",
+            "did:ethr:rinkeby:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+            "did:ethr:rinkeby:0xB9C5714089478a327F09197987f16f9E5d936E8a",
+            "did:ethr:rinkeby:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner",
+            "did:ethr:0x1:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+            "did:ethr:0x1:0xB9C5714089478a327F09197987f16f9E5d936E8a",
+            "did:ethr:0x1:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner",
+            "did:ethr:0x04:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+            "did:ethr:0x04:0xB9C5714089478a327F09197987f16f9E5d936E8a",
+            "did:ethr:0x04:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner"
+        )
+        validNetworkedDIDs.forEach {
+            val normalizedDid = EthrDIDResolver.normalizeDid(it).toLowerCase()
+            println("normalizing `$it` got `$normalizedDid`")
+            assertThat(normalizedDid).isNotEmpty()
+            assertThat(normalizedDid).doesNotContain("#owner")
+        }
+    }
 }

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -408,4 +408,30 @@ class EthrDIDResolverTest {
             assertThat(normalizedDid).doesNotContain("#owner")
         }
     }
+
+    @Test
+    fun `can extract address from networked DIDs`() {
+        val validNetworkedDIDs = listOf(
+            "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+            "did:ethr:0xB9C5714089478a327F09197987f16f9E5d936E8a",
+            "did:ethr:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner",
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+            "did:ethr:mainnet:0xB9C5714089478a327F09197987f16f9E5d936E8a",
+            "did:ethr:mainnet:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner",
+            "did:ethr:rinkeby:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+            "did:ethr:rinkeby:0xB9C5714089478a327F09197987f16f9E5d936E8a",
+            "did:ethr:rinkeby:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner",
+            "did:ethr:0x1:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+            "did:ethr:0x1:0xB9C5714089478a327F09197987f16f9E5d936E8a",
+            "did:ethr:0x1:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner",
+            "did:ethr:0x04:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+            "did:ethr:0x04:0xB9C5714089478a327F09197987f16f9E5d936E8a",
+            "did:ethr:0x04:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner"
+        )
+        validNetworkedDIDs.forEach {
+            val address = EthrDIDResolver.extractAddress(it).toLowerCase()
+            println("extracting address from `$it` got `$address`")
+            assertThat(address).isEqualTo("0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        }
+    }
 }

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -79,7 +79,8 @@ class EthrDIDResolverTest {
         val http = mockk<HttpClient>()
         val rpc = JsonRPC("", http)
         val realAddress = "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
-        val lastChanged = "0x00000000000000000000000000000000000000000000000000000000002a8a7d".hexToBigInteger()
+        val lastChanged =
+            "0x00000000000000000000000000000000000000000000000000000000002a8a7d".hexToBigInteger()
 
         //language=json
         val cannedLogsResponse =
@@ -87,7 +88,12 @@ class EthrDIDResolverTest {
         coEvery { http.urlPost(any(), any(), any()) } returns cannedLogsResponse
 
         val logResponse =
-            rpc.getLogs("0xregistry", listOf(null, realAddress.hexToBytes32()), lastChanged, lastChanged)
+            rpc.getLogs(
+                "0xregistry",
+                listOf(null, realAddress.hexToBytes32()),
+                lastChanged,
+                lastChanged
+            )
 
         assertThat(logResponse).all {
             isNotNull()
@@ -126,7 +132,12 @@ class EthrDIDResolverTest {
         val realAddress = "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
 
         val rpc = spyk(JsonRPC(""))
-        coEvery { rpc.ethCall(any(), eq("0xf96d0f9f000000000000000000000000f3beac30c498d9e26865f34fcaa57dbb935b0d74")) }
+        coEvery {
+            rpc.ethCall(
+                any(),
+                eq("0xf96d0f9f000000000000000000000000f3beac30c498d9e26865f34fcaa57dbb935b0d74")
+            )
+        }
             .returns("0x00000000000000000000000000000000000000000000000000000000002a8a7d")
         val cannedResponses: List<List<JsonRpcLogItem>> = listOf(
             listOf(
@@ -301,7 +312,8 @@ class EthrDIDResolverTest {
             emptyList()
         )
 
-        val resolver = EthrDIDResolver(rpc)
+        val resolver = EthrDIDResolver.Builder()
+            .addNetwork(EthrDIDNetwork("", "0xregistry", rpc, "0x1")).build()
         val ddo = resolver.resolve("0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656")
 
         val expectedDDO = EthrDIDTestHelpers
@@ -543,7 +555,8 @@ class EthrDIDResolverTest {
     @Test
     fun `can resolve generic did when only provided with mainnet config`() {
         val http = mockk<HttpClient>()
-        val referenceDDO = EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val referenceDDO =
+            EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
 
         val addressHex = "b9c5714089478a327f09197987f16f9e5d936e8a"
 
@@ -563,7 +576,13 @@ class EthrDIDResolverTest {
             )
         } returns "0x0000000000000000000000000000000000000000000000000000000000000000"
         //canned response for getLogs
-        coEvery { http.urlPost(eq("mainnetRPC"), any(), any()) } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
+        coEvery {
+            http.urlPost(
+                eq("mainnetRPC"),
+                any(),
+                any()
+            )
+        } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
 
 
         val resolver = EthrDIDResolver.Builder()
@@ -598,7 +617,13 @@ class EthrDIDResolverTest {
             )
         } returns "0x0000000000000000000000000000000000000000000000000000000000000000"
         //canned response for getLogs
-        coEvery { http.urlPost(any(), any(), any()) } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
+        coEvery {
+            http.urlPost(
+                any(),
+                any(),
+                any()
+            )
+        } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
 
 
         val resolver = EthrDIDResolver.Builder()
@@ -607,16 +632,21 @@ class EthrDIDResolverTest {
             .build()
 
         val genericDDO = resolver.resolve("did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a")
-        val mainnetDDO = resolver.resolve("did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a")
-        val mainnetDDO0x1 = resolver.resolve("did:ethr:0x1:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val mainnetDDO =
+            resolver.resolve("did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val mainnetDDO0x1 =
+            resolver.resolve("did:ethr:0x1:0xb9c5714089478a327f09197987f16f9e5d936e8a")
 
-        val referenceDDO = EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val referenceDDO =
+            EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
         assertThat(genericDDO).isEqualTo(referenceDDO)
         assertThat(mainnetDDO).isEqualTo(referenceDDO)
         assertThat(mainnetDDO0x1).isEqualTo(referenceDDO)
 
-        val rinkebyDDO = resolver.resolve("did:ethr:rinkeby:0xb9c5714089478a327f09197987f16f9e5d936e8a")
-        val rinkebyDDO0x04 = resolver.resolve("did:ethr:0x04:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val rinkebyDDO =
+            resolver.resolve("did:ethr:rinkeby:0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val rinkebyDDO0x04 =
+            resolver.resolve("did:ethr:0x04:0xb9c5714089478a327f09197987f16f9e5d936e8a")
 
         assertThat(rinkebyDDO).isEqualTo(EthrDIDTestHelpers.mockDocForAddress("did:ethr:rinkeby:0xb9c5714089478a327f09197987f16f9e5d936e8a"))
         assertThat(rinkebyDDO0x04).isEqualTo(EthrDIDTestHelpers.mockDocForAddress("did:ethr:0x04:0xb9c5714089478a327f09197987f16f9e5d936e8a"))
@@ -625,7 +655,8 @@ class EthrDIDResolverTest {
     @Test
     fun `can resolve generic did when only provided with 0x1 config`() {
         val http = mockk<HttpClient>()
-        val referenceDDO = EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val referenceDDO =
+            EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
 
         val addressHex = "b9c5714089478a327f09197987f16f9e5d936e8a"
 
@@ -645,7 +676,13 @@ class EthrDIDResolverTest {
             )
         } returns "0x0000000000000000000000000000000000000000000000000000000000000000"
         //canned response for getLogs
-        coEvery { http.urlPost(eq("mainnetRPC"), any(), any()) } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
+        coEvery {
+            http.urlPost(
+                eq("mainnetRPC"),
+                any(),
+                any()
+            )
+        } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
 
 
         val resolver = EthrDIDResolver.Builder()
@@ -756,7 +793,10 @@ class EthrDIDResolverTest {
     @Test
     fun `throws when registry is not configured`() {
         val rpc = mockk<JsonRPC>()
-        val resolver = EthrDIDResolver(rpc, "")
+        val resolver =
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "", rpc, "0x1"))
+                .build()
         coAssert {
             resolver.resolve("did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a")
         }.thrownError {
@@ -772,9 +812,10 @@ class EthrDIDResolverTest {
             rpc.ethCall(any(), any())
         } throws JsonRpcException(JSON_RPC_INTERNAL_ERROR_CODE, "fake error")
 
-        val resolver = EthrDIDResolver(rpc)
+        val resolver = EthrDIDResolver.Builder()
+            .addNetwork(EthrDIDNetwork("", "0xregistry", rpc, "0x1")).build()
         coAssert {
-            resolver.lastChanged("0xb9c5714089478a327f09197987f16f9e5d936e8a")
+            resolver.lastChanged("0xb9c5714089478a327f09197987f16f9e5d936e8a", rpc, "0xregistry")
         }.thrownError {
             isInstanceOf(DidResolverError::class)
         }

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -434,4 +434,30 @@ class EthrDIDResolverTest {
             assertThat(address).isEqualTo("0xb9c5714089478a327f09197987f16f9e5d936e8a")
         }
     }
+
+    @Test
+    fun `can extract network from networked DIDs`() {
+        val validNetworkedDIDs = mapOf(
+            "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a" to "",
+            "did:ethr:0xB9C5714089478a327F09197987f16f9E5d936E8a" to "",
+            "did:ethr:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner" to "",
+            "did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a" to "mainnet",
+            "did:ethr:mainnet:0xB9C5714089478a327F09197987f16f9E5d936E8a" to "mainnet",
+            "did:ethr:mainnet:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner" to "mainnet",
+            "did:ethr:rinkeby:0xb9c5714089478a327f09197987f16f9e5d936e8a" to "rinkeby",
+            "did:ethr:rinkeby:0xB9C5714089478a327F09197987f16f9E5d936E8a" to "rinkeby",
+            "did:ethr:rinkeby:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner" to "rinkeby",
+            "did:ethr:0x1:0xb9c5714089478a327f09197987f16f9e5d936e8a" to "0x1",
+            "did:ethr:0x1:0xB9C5714089478a327F09197987f16f9E5d936E8a" to "0x1",
+            "did:ethr:0x1:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner" to "0x1",
+            "did:ethr:0x04:0xb9c5714089478a327f09197987f16f9e5d936e8a" to "0x04",
+            "did:ethr:0x04:0xB9C5714089478a327F09197987f16f9E5d936E8a" to "0x04",
+            "did:ethr:0x04:0xB9C5714089478a327F09197987f16f9E5d936E8a#owner" to "0x04"
+        )
+        validNetworkedDIDs.forEach {(did, expectedNetwork) ->
+            val extractedNetwork = EthrDIDResolver.extractNetwork(did).toLowerCase()
+            println("extracting address from `$did` got `$extractedNetwork`")
+            assertThat(extractedNetwork).isEqualTo(expectedNetwork)
+        }
+    }
 }

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/RegistryMapTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/RegistryMapTest.kt
@@ -1,0 +1,65 @@
+package me.uport.sdk.ethrdid
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import me.uport.sdk.jsonrpc.JsonRPC
+import org.junit.Test
+
+@Suppress("UNUSED_VARIABLE")
+class RegistryMapTest {
+    private val mainnetLocal = EthrDIDNetwork("mainnet", "0x1234", JsonRPC("http://localhost:8545"), chainId = "0x1")
+    private val rinkebyLocal = EthrDIDNetwork("rinkeby", "0x4321", JsonRPC("http://localhost:8545"), chainId = "0x04")
+
+    @Test
+    fun `can get network by direct ID`() {
+        val tested = RegistryMap()
+            .registerNetwork(mainnetLocal)
+            .registerNetwork(rinkebyLocal)
+
+        assertThat(tested["0x1"]).isEqualTo(mainnetLocal)
+        assertThat(tested["0x04"]).isEqualTo(rinkebyLocal)
+    }
+
+    @Test
+    fun `can get network by clean ID`() {
+        val tested = RegistryMap()
+            .registerNetwork(mainnetLocal)
+            .registerNetwork(rinkebyLocal)
+
+        assertThat(tested["0x01"]).isEqualTo(mainnetLocal)
+        assertThat(tested["0x4"]).isEqualTo(rinkebyLocal)
+    }
+
+    @Test
+    fun `can get network by name`() {
+        val tested = RegistryMap()
+            .registerNetwork(mainnetLocal)
+            .registerNetwork(rinkebyLocal)
+
+        assertThat(tested["mainnet"]).isEqualTo(mainnetLocal)
+    }
+
+    @Test
+    fun `can get empty network name`() {
+        val tested = RegistryMap()
+            .registerNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("localhost")))
+
+        assertThat {
+            val unused = tested[""].registryAddress
+        }.doesNotThrowAnyException()
+    }
+
+    @Test
+    fun `throws when no network found`() {
+        val tested = RegistryMap()
+            .registerNetwork(mainnetLocal)
+            .registerNetwork(rinkebyLocal)
+
+        assertThat {
+            val unused = tested["0x6123"]
+        }.thrownError {
+            isInstanceOf(IllegalArgumentException::class)
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-all.zip

--- a/jwt-test/build.gradle
+++ b/jwt-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation project(":ethr-did")
+    api "com.github.uport-project.kotlin-common:test-helpers:$uport_kotlin_common_version"
 
     testImplementation "junit:junit:$junit_version"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"

--- a/jwt-test/src/main/java/me/uport/sdk/jwt/test/EthrDIDTestHelpers.kt
+++ b/jwt-test/src/main/java/me/uport/sdk/jwt/test/EthrDIDTestHelpers.kt
@@ -6,9 +6,18 @@ open class EthrDIDTestHelpers {
 
     companion object {
 
-        fun mockDocForAddress(address: String): EthrDIDDocument {
-            val did = "did:ethr:$address"
-            return EthrDIDDocument.fromJson("""
+        //language=RegExp
+        private val didParsePattern = "^(did:)?((\\w+):)?((\\w+):)?(0x[0-9a-fA-F]{40})".toRegex()
+
+        fun mockDocForAddress(potentialDID: String): EthrDIDDocument {
+
+            val matchResult = didParsePattern.find(potentialDID)
+                ?: throw IllegalArgumentException("can't parse potentialDID or did")
+            val (_, _, _, _, network, address) = matchResult.destructured
+            val did = if (network.isBlank() || network == "mainnet") "did:ethr:$address" else "did:ethr:$network:$address"
+
+            return EthrDIDDocument.fromJson(
+                """
             {
               "@context": "https://w3id.org/did/v1",
               "id": "$did",
@@ -20,8 +29,8 @@ open class EthrDIDTestHelpers {
               "authentication": [{
                    "type": "Secp256k1SignatureAuthentication2018",
                    "publicKey": "$did#owner"}]
-            }
-        """.trimIndent())
+            }""".trimIndent()
+            )
         }
     }
 

--- a/jwt-test/src/test/java/me/uport/sdk/jwt/test/EthrDidDocumentTestHelpersTest.kt
+++ b/jwt-test/src/test/java/me/uport/sdk/jwt/test/EthrDidDocumentTestHelpersTest.kt
@@ -2,6 +2,7 @@ package me.uport.sdk.jwt.test
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import me.uport.sdk.ethrdid.EthrDIDDocument
 import me.uport.sdk.universaldid.AuthenticationEntry
 import me.uport.sdk.universaldid.PublicKeyEntry
@@ -104,5 +105,14 @@ class EthrDIDTestHelpersTest {
         val ddo = EthrDIDTestHelpers.mockDocForAddress("did:ethr:mainnet:$address")
 
         assertThat(ddo).isEqualTo(referenceDDO)
+    }
+
+    @Test
+    fun `throws error when given improper input`() {
+        assertThat {
+            EthrDIDTestHelpers.mockDocForAddress("bla bla")
+        }.thrownError {
+            isInstanceOf(IllegalArgumentException::class)
+        }
     }
 }

--- a/jwt-test/src/test/java/me/uport/sdk/jwt/test/EthrDidDocumentTestHelpersTest.kt
+++ b/jwt-test/src/test/java/me/uport/sdk/jwt/test/EthrDidDocumentTestHelpersTest.kt
@@ -33,4 +33,76 @@ class EthrDIDTestHelpersTest {
 
         assertThat(ddo).isEqualTo(referenceDDO)
     }
+
+    @Test
+    fun `can create mock ethr-did document from a did`() {
+        val address = "0xb9c5714089478a327f09197987f16f9e5d936e8a"
+        val did = "did:ethr:$address"
+
+        val referenceDDO = EthrDIDDocument(
+                did,
+                listOf(PublicKeyEntry(
+                        "$did#owner",
+                        PublicKeyType.Secp256k1VerificationKey2018,
+                        did,
+                        address
+                )),
+                listOf(AuthenticationEntry(
+                        PublicKeyType.Secp256k1SignatureAuthentication2018,
+                        "$did#owner"
+                ))
+        )
+
+        val ddo = EthrDIDTestHelpers.mockDocForAddress(did)
+
+        assertThat(ddo).isEqualTo(referenceDDO)
+    }
+
+    @Test
+    fun `can create mock ethr-did document from a networked did`() {
+        val address = "0xb9c5714089478a327f09197987f16f9e5d936e8a"
+        val did = "did:ethr:rinkeby:$address"
+
+        val referenceDDO = EthrDIDDocument(
+            did,
+            listOf(PublicKeyEntry(
+                "$did#owner",
+                PublicKeyType.Secp256k1VerificationKey2018,
+                did,
+                address
+            )),
+            listOf(AuthenticationEntry(
+                PublicKeyType.Secp256k1SignatureAuthentication2018,
+                "$did#owner"
+            ))
+        )
+
+        val ddo = EthrDIDTestHelpers.mockDocForAddress(did)
+
+        assertThat(ddo).isEqualTo(referenceDDO)
+    }
+
+    @Test
+    fun `can create mock ethr-did document for mainnet DID`() {
+        val address = "0xb9c5714089478a327f09197987f16f9e5d936e8a"
+        val expectedDID = "did:ethr:$address"
+
+        val referenceDDO = EthrDIDDocument(
+            expectedDID,
+            listOf(PublicKeyEntry(
+                "$expectedDID#owner",
+                PublicKeyType.Secp256k1VerificationKey2018,
+                expectedDID,
+                address
+            )),
+            listOf(AuthenticationEntry(
+                PublicKeyType.Secp256k1SignatureAuthentication2018,
+                "$expectedDID#owner"
+            ))
+        )
+
+        val ddo = EthrDIDTestHelpers.mockDocForAddress("did:ethr:mainnet:$address")
+
+        assertThat(ddo).isEqualTo(referenceDDO)
+    }
 }

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonConfiguration
 import kotlinx.serialization.json.JsonException
 import me.uport.sdk.core.*
+import me.uport.sdk.ethrdid.EthrDIDNetwork
 import me.uport.sdk.ethrdid.EthrDIDResolver
 import me.uport.sdk.httpsdid.WebDIDResolver
 import me.uport.sdk.jsonrpc.JsonRPC
@@ -81,7 +82,16 @@ class JWTTools(
             val defaultRPC = JsonRPC(preferredNetwork?.rpcUrl ?: Networks.mainnet.rpcUrl)
             val defaultRegistry = preferredNetwork?.ethrDidRegistry
                 ?: Networks.mainnet.ethrDidRegistry
-            UniversalDID.registerResolver(EthrDIDResolver(defaultRPC, defaultRegistry))
+            UniversalDID.registerResolver(
+                EthrDIDResolver.Builder().addNetwork(
+                    EthrDIDNetwork(
+                        "",
+                        defaultRegistry,
+                        defaultRPC,
+                        "0x1"
+                    )
+                ).build()
+            )
         }
 
         // register default Uport DID resolver if Universal DID is unable to resolve blank Uport DID

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -83,14 +83,9 @@ class JWTTools(
             val defaultRegistry = preferredNetwork?.ethrDidRegistry
                 ?: Networks.mainnet.ethrDidRegistry
             UniversalDID.registerResolver(
-                EthrDIDResolver.Builder().addNetwork(
-                    EthrDIDNetwork(
-                        "",
-                        defaultRegistry,
-                        defaultRPC,
-                        "0x1"
-                    )
-                ).build()
+                EthrDIDResolver.Builder()
+                    .addNetwork(EthrDIDNetwork("", defaultRegistry, defaultRPC, "0x1"))
+                    .build()
             )
         }
 

--- a/jwt/src/test/java/me/uport/sdk/jwt/TimestampTests.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/TimestampTests.kt
@@ -31,6 +31,8 @@ class TimestampTests {
     @Before
     fun `mock DID documents before every test`() {
         val jrpc = mockk<JsonRPC>()
+        //intentionally suppress deprecation here to test that the old constructor still works
+        @Suppress("DEPRECATION")
         val resolver = spyk(EthrDIDResolver(jrpc))
         coEvery {
             resolver.resolve(any())


### PR DESCRIPTION
### What's here

This changeset adds the ability to resolve ethr-dids of the form
`"did:ethr:<network identifier>:0xaddress"` into their corresponding DID documents.

Example:
```kotlin
"did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a"
"did:ethr:mainnet:0xb9c5714089478a327f09197987f16f9e5d936e8a"
"did:ethr:rinkeby:0xB9C5714089478a327F09197987f16f9E5d936E8a"
"did:ethr:0x1:0xb9c5714089478a327f09197987f16f9e5d936e8a"
"did:ethr:0x04:0xb9c5714089478a327f09197987f16f9e5d936e8a"
```

This requires an ability to configure `EthrDIDResolver` to support multiple networks.
At the same time, we don't want to lose the ability to test this and higher level APIs, so the blockchain access layer abstraction should still be possible.

Also, the generic ethr-DIDs of previous versions still need to work.
Mainnet ethr-dids need to resolve to identical documents as the old generic DIDs.

### Steps to make this happen

* define `EthrDIDNetwork` configuration class, with the ability to abstract the blockchain access (also useful for testing)
* add a `EthrDIDResolver.Builder()` pattern to make it easy to provide multiple networks to the resolver.
* deprecate the existing `constructor` for `EthrDIDResolver`, with an included Intellij/AndroidStudio quick fix to easily migrate to the builder pattern using just a keystroke.
* add support for network spec in the DID parser
* pick the proper network and configuration when resolving a DID
* make sure `mainnet` DIDs and generic DIDs resolve to identical documents.
* and a lot of tests to ensure there are no breaking changes and to support all of the above.

### Notes

* The next major release will remove the `EthrDIDResolver` constructor.
* network identifiers can also be chain IDs, which is not included in the spec.
* There is no enforcement that network names and chain IDs be identical to EIP155, but special treatment is done for the `""`, `"mainnet"`, `"0x1"`, and `"0x01"`