### PR TITLE
[bugfix] crash in ethr-did-resolver for nodes that don't reply with logs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@
 buildscript {
 
     ext {
-        kotlin_version = '1.3.41'
-        kotlin_serialization_version = '0.11.1'
-        coroutines_version = "1.2.0"
+        kotlin_version = '1.3.50'
+        kotlin_serialization_version = '0.12.0'
+        coroutines_version = "1.3.0"
 
         junit_version = "4.12"
         mockk_version = "1.9.3"

--- a/ethr-did/build.gradle
+++ b/ethr-did/build.gradle
@@ -25,4 +25,5 @@ dependencies {
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
     testImplementation project(":jwt-test")
+    testImplementation "com.github.uport-project.kotlin-common:test-helpers:$uport_kotlin_common_version"
 }

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -70,7 +70,8 @@ class EthrDIDResolverTest {
         val rpc = JsonRPC(Networks.rinkeby.rpcUrl, http)
         val realAddress = "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
         val resolver = EthrDIDResolver(rpc)
-        val lastChanged = "0x00000000000000000000000000000000000000000000000000000000002a8a7d".hexToBigInteger()
+        val lastChanged =
+            "0x00000000000000000000000000000000000000000000000000000000002a8a7d".hexToBigInteger()
 
         //language=json
         val cannedLogsResponse =
@@ -78,7 +79,12 @@ class EthrDIDResolverTest {
         coEvery { http.urlPost(any(), any(), any()) } returns cannedLogsResponse
 
         val logResponse =
-            rpc.getLogs(resolver.registryAddress, listOf(null, realAddress.hexToBytes32()), lastChanged, lastChanged)
+            rpc.getLogs(
+                resolver.registryAddress,
+                listOf(null, realAddress.hexToBytes32()),
+                lastChanged,
+                lastChanged
+            )
 
         assertThat(logResponse).all {
             isNotNull()
@@ -117,7 +123,12 @@ class EthrDIDResolverTest {
         val realAddress = "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
 
         val rpc = spyk(JsonRPC(Networks.rinkeby.rpcUrl))
-        coEvery { rpc.ethCall(any(), eq("0xf96d0f9f000000000000000000000000f3beac30c498d9e26865f34fcaa57dbb935b0d74")) }
+        coEvery {
+            rpc.ethCall(
+                any(),
+                eq("0xf96d0f9f000000000000000000000000f3beac30c498d9e26865f34fcaa57dbb935b0d74")
+            )
+        }
             .returns("0x00000000000000000000000000000000000000000000000000000000002a8a7d")
         val cannedResponses: List<List<JsonRpcLogItem>> = listOf(
             listOf(
@@ -184,12 +195,18 @@ class EthrDIDResolverTest {
 
         coEvery {
             //mock the lookup owner call to return itself
-            rpc.ethCall(any(), eq("0x8733d4e800000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656"))
+            rpc.ethCall(
+                any(),
+                eq("0x8733d4e800000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656")
+            )
         }.returns("0x00000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656")
 
         coEvery {
             //mock the lastChanged call to point to block number 4680310 (0x476A76)
-            rpc.ethCall(any(), eq("0xf96d0f9f00000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656"))
+            rpc.ethCall(
+                any(),
+                eq("0xf96d0f9f00000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656")
+            )
         }.returns("0x0000000000000000000000000000000000000000000000000000000000476A76")
 
         coEvery {
@@ -246,6 +263,47 @@ class EthrDIDResolverTest {
               "@context": "https://w3id.org/did/v1"
             }""".trimIndent()
         )
+
+        assertThat(ddo).isEqualTo(expectedDDO)
+    }
+
+    @Test
+    fun `resolves with default doc when the RPC logs are blank or corrupted`() = runBlocking {
+        val rpc = mockk<JsonRPC>()
+
+        coEvery {
+            //mock the lookup owner call to return itself
+            rpc.ethCall(
+                any(),
+                eq("0x8733d4e800000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656")
+            )
+        }.returns("0x00000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656")
+
+        coEvery {
+            //mock the lastChanged call to point to block numbers 9 and 8
+            rpc.ethCall(
+                any(),
+                eq("0xf96d0f9f00000000000000000000000062d283fe6939c01fc88f02c6d2c9a547cc3e2656")
+            )
+        }.returnsMany(
+            listOf(
+                "0x0000000000000000000000000000000000000000000000000000000000000009",
+                "0x0000000000000000000000000000000000000000000000000000000000000008"
+            )
+        )
+
+        coEvery {
+            rpc.getLogs(address = any(), topics = any(), fromBlock = any(), toBlock = any())
+        }.returnsMany(
+            emptyList(),
+            emptyList()
+        )
+
+        val resolver = EthrDIDResolver(rpc)
+        val ddo = resolver.resolve("0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656")
+
+        val expectedDDO = EthrDIDTestHelpers
+            .mockDocForAddress("0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656")
 
         assertThat(ddo).isEqualTo(expectedDDO)
     }
@@ -324,7 +382,8 @@ class EthrDIDResolverTest {
     fun `can resolve real did`() = runBlocking {
         val http = mockk<HttpClient>()
 
-        val referenceDDO = EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
+        val referenceDDO =
+            EthrDIDTestHelpers.mockDocForAddress("0xb9c5714089478a327f09197987f16f9e5d936e8a")
 
         val addressHex = "b9c5714089478a327f09197987f16f9e5d936e8a"
 
@@ -344,7 +403,13 @@ class EthrDIDResolverTest {
             )
         } returns "0x0000000000000000000000000000000000000000000000000000000000000000"
         //canned response for getLogs
-        coEvery { http.urlPost(any(), any(), any()) } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
+        coEvery {
+            http.urlPost(
+                any(),
+                any(),
+                any()
+            )
+        } returns """{"jsonrpc":"2.0","id":1,"result":[]}"""
 
         val resolver = EthrDIDResolver(rpc)
         val ddo = resolver.resolve("did:ethr:0x$addressHex")

--- a/jwt/src/main/java/me/uport/sdk/jwt/model/JwtPayload.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/model/JwtPayload.kt
@@ -2,6 +2,7 @@
 
 package me.uport.sdk.jwt.model
 
+import kotlinx.serialization.ContextualSerialization
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -50,7 +51,7 @@ data class JwtPayload(
      */
     @Serializable(with = ArbitraryMapSerializer::class)
     @SerialName("claim")
-    val claims: Map<String, Any>? = null,
+    val claims: Map<String, @ContextualSerialization Any>? = null,
     /**
      * Specific to Private Chain
      * Also includes dad
@@ -62,7 +63,8 @@ data class JwtPayload(
     val acc: String? = null //Fuel token used to authenticate on above fct url
 ) {
     companion object {
-        fun fromJson(payloadString: String): JwtPayload = jsonAdapter.parse(serializer(), payloadString)
+        fun fromJson(payloadString: String): JwtPayload =
+            jsonAdapter.parse(serializer(), payloadString)
 
         private val jsonAdapter = Json(JsonConfiguration(strictMode = false))
     }

--- a/jwt/src/test/java/me/uport/sdk/jwt/SerializationTesting.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/SerializationTesting.kt
@@ -4,6 +4,7 @@ package me.uport.sdk.jwt
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import kotlinx.serialization.ContextualSerialization
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -23,7 +24,7 @@ class SerializationTesting {
     data class CompoundTestObject(
         //use custom serializers for arbitrary map types
         @Serializable(with = ArbitraryMapSerializer::class)
-        val generic: Map<String, Any?>
+        val generic: Map<String, @ContextualSerialization Any?>
     )
 
     @Test


### PR DESCRIPTION
In case the RPC node can't provide logs, the ethr-did-resolver would crash.
This PR fixes the crash by skipping the blocks without logs, returning the default DID document (with eventual owner change).

This situation comes up when working against a local node with ganache (I was using 2.1.0)

A test has been added to simulate the blank logs situation.