### PR TITLE
refactor: update dependency stack and isolate implementation details

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,10 +16,11 @@ buildscript {
         okhttp_version = "3.14.1"
 
         bivrost_version = "v0.7.1"
-        kmnid_version = "0.3.2"
-        kethereum_version = "0.75.1"
+        kmnid_version = "0.4.0"
+        kethereum_version = "0.76.1"
+        khex_version = "1.0.0-RC3"
         spongycastle_version = "1.58.0.0"
-        uport_kotlin_common_version = "0.1.1"
+        uport_kotlin_common_version = "acc69d6"//"0.2.0"
 
         current_release_version = "0.3.1"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,11 @@ buildscript {
         okhttp_version = "3.14.1"
 
         bivrost_version = "v0.7.1"
-        kmnid_version = "0.4.0"
+        kmnid_version = "0.4.1"
         kethereum_version = "0.76.1"
         khex_version = "1.0.0-RC3"
         spongycastle_version = "1.58.0.0"
-        uport_kotlin_common_version = "0.3.0"
+        uport_kotlin_common_version = "0.3.1"
 
         current_release_version = "0.3.1"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
         kethereum_version = "0.76.1"
         khex_version = "1.0.0-RC3"
         spongycastle_version = "1.58.0.0"
-        uport_kotlin_common_version = "acc69d6"//"0.2.0"
+        uport_kotlin_common_version = "0.3.0"
 
         current_release_version = "0.3.1"
     }

--- a/ethr-did/build.gradle
+++ b/ethr-did/build.gradle
@@ -16,10 +16,10 @@ dependencies {
 
     api "com.github.komputing.kethereum:extensions:$kethereum_version"
     api "com.github.komputing.kethereum:model:$kethereum_version"
+    api "com.github.komputing.khex:extensions-jvm:$khex_version"
     implementation "com.github.komputing.kethereum:base58:$kethereum_version"
     implementation "com.github.komputing.kethereum:crypto:$kethereum_version"
     implementation "com.github.komputing.kethereum:crypto_impl_spongycastle:$kethereum_version"
-    implementation "com.github.komputing.khex:extensions-jvm:$khex_version"
 
     implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
     implementation "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"

--- a/ethr-did/build.gradle
+++ b/ethr-did/build.gradle
@@ -21,9 +21,9 @@ dependencies {
     implementation "com.github.komputing.kethereum:crypto:$kethereum_version"
     implementation "com.github.komputing.kethereum:crypto_impl_spongycastle:$kethereum_version"
 
-    implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
-    implementation "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
-    implementation "com.github.uport-project.kotlin-common:signer-common:$uport_kotlin_common_version"
+    api "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
+    api "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
+    api "com.github.uport-project.kotlin-common:signer-common:$uport_kotlin_common_version"
 
     api project(":universal-did")
 

--- a/ethr-did/build.gradle
+++ b/ethr-did/build.gradle
@@ -16,9 +16,15 @@ dependencies {
 
     api "com.github.komputing.kethereum:extensions:$kethereum_version"
     api "com.github.komputing.kethereum:model:$kethereum_version"
+    implementation "com.github.komputing.kethereum:base58:$kethereum_version"
+    implementation "com.github.komputing.kethereum:crypto:$kethereum_version"
+    implementation "com.github.komputing.kethereum:crypto_impl_spongycastle:$kethereum_version"
+    implementation "com.github.komputing.khex:extensions-jvm:$khex_version"
 
-    api "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
-    api "com.github.uport-project.kotlin-common:signer-common:$uport_kotlin_common_version"
+    implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
+    implementation "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
+    implementation "com.github.uport-project.kotlin-common:signer-common:$uport_kotlin_common_version"
+
     api project(":universal-did")
 
     testImplementation "junit:junit:$junit_version"

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDID.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDID.kt
@@ -10,9 +10,9 @@ import me.uport.sdk.universaldid.PublicKeyType
 import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.model.Address
 import org.kethereum.model.createTransactionWithDefaults
-import org.walleth.khex.hexToByteArray
-import org.walleth.khex.prepend0xPrefix
-import org.walleth.khex.toHexString
+import org.komputing.khex.extensions.hexToByteArray
+import org.komputing.khex.extensions.prepend0xPrefix
+import org.komputing.khex.extensions.toHexString
 import pm.gnosis.model.Solidity
 import java.math.BigInteger
 

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -10,7 +10,7 @@ import me.uport.sdk.ethrdid.EthereumDIDRegistry.Events.DIDAttributeChanged
 import me.uport.sdk.ethrdid.EthereumDIDRegistry.Events.DIDDelegateChanged
 import me.uport.sdk.ethrdid.EthereumDIDRegistry.Events.DIDOwnerChanged
 import me.uport.sdk.jsonrpc.JsonRPC
-import me.uport.sdk.jsonrpc.JsonRpcException
+import me.uport.sdk.jsonrpc.model.exceptions.JsonRpcException
 import me.uport.sdk.signer.Signer
 import me.uport.sdk.signer.bytes32ToString
 import me.uport.sdk.signer.hexToBytes32
@@ -23,9 +23,9 @@ import me.uport.sdk.universaldid.PublicKeyType.Companion.veriKey
 import org.kethereum.encodings.encodeToBase58String
 import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.extensions.toHexStringNoPrefix
-import org.walleth.khex.hexToByteArray
-import org.walleth.khex.prepend0xPrefix
-import org.walleth.khex.toHexString
+import org.komputing.khex.extensions.hexToByteArray
+import org.komputing.khex.extensions.prepend0xPrefix
+import org.komputing.khex.extensions.toHexString
 import pm.gnosis.model.Solidity
 import java.math.BigInteger
 import java.util.*

--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/RegistryMap.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/RegistryMap.kt
@@ -1,7 +1,7 @@
 package me.uport.sdk.ethrdid
 
-import org.walleth.khex.clean0xPrefix
-import org.walleth.khex.prepend0xPrefix
+import org.komputing.khex.extensions.clean0xPrefix
+import org.komputing.khex.extensions.prepend0xPrefix
 
 /**
  * This encapsulates a mapping of names and chainIDs to [EthrDIDNetwork] configuration instances

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -13,10 +13,10 @@ import kotlinx.coroutines.runBlocking
 import me.uport.sdk.core.HttpClient
 import me.uport.sdk.core.Networks
 import me.uport.sdk.ethrdid.EthereumDIDRegistry.Events.DIDOwnerChanged
-import me.uport.sdk.jsonrpc.JSON_RPC_INTERNAL_ERROR_CODE
 import me.uport.sdk.jsonrpc.JsonRPC
-import me.uport.sdk.jsonrpc.JsonRpcException
-import me.uport.sdk.jsonrpc.JsonRpcLogItem
+import me.uport.sdk.jsonrpc.model.JsonRpcLogItem
+import me.uport.sdk.jsonrpc.model.exceptions.JSON_RPC_INTERNAL_ERROR_CODE
+import me.uport.sdk.jsonrpc.model.exceptions.JsonRpcException
 import me.uport.sdk.jwt.test.EthrDIDTestHelpers
 import me.uport.sdk.signer.hexToBytes32
 import me.uport.sdk.signer.utf8

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDTest.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.runBlocking
 import me.uport.sdk.jsonrpc.JsonRPC
 import me.uport.sdk.signer.KPSigner
 import org.junit.Test
-import org.walleth.khex.prepend0xPrefix
+import org.komputing.khex.extensions.prepend0xPrefix
 import java.math.BigInteger
 
 class EthrDIDTest {

--- a/jwt-test/build.gradle
+++ b/jwt-test/build.gradle
@@ -7,6 +7,7 @@ project.ext.description = "tools to enable testing of the did-jwt library"
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
 
     implementation project(":ethr-did")
     api "com.github.uport-project.kotlin-common:test-helpers:$uport_kotlin_common_version"

--- a/jwt-test/src/main/java/me/uport/sdk/jwt/test/EthrDIDTestHelpers.kt
+++ b/jwt-test/src/main/java/me/uport/sdk/jwt/test/EthrDIDTestHelpers.kt
@@ -1,6 +1,9 @@
 package me.uport.sdk.jwt.test
 
 import me.uport.sdk.ethrdid.EthrDIDDocument
+import me.uport.sdk.universaldid.AuthenticationEntry
+import me.uport.sdk.universaldid.PublicKeyEntry
+import me.uport.sdk.universaldid.PublicKeyType
 
 open class EthrDIDTestHelpers {
 
@@ -14,22 +17,25 @@ open class EthrDIDTestHelpers {
             val matchResult = didParsePattern.find(potentialDID)
                 ?: throw IllegalArgumentException("can't parse potentialDID or did")
             val (_, _, _, _, network, address) = matchResult.destructured
-            val did = if (network.isBlank() || network == "mainnet") "did:ethr:$address" else "did:ethr:$network:$address"
+            val did =
+                if (network.isBlank() || network == "mainnet") "did:ethr:$address" else "did:ethr:$network:$address"
 
-            return EthrDIDDocument.fromJson(
-                """
-            {
-              "@context": "https://w3id.org/did/v1",
-              "id": "$did",
-              "publicKey": [{
-                   "id": "$did#owner",
-                   "type": "Secp256k1VerificationKey2018",
-                   "owner": "$did",
-                   "ethereumAddress": "$address"}],
-              "authentication": [{
-                   "type": "Secp256k1SignatureAuthentication2018",
-                   "publicKey": "$did#owner"}]
-            }""".trimIndent()
+            return EthrDIDDocument(
+                id = did,
+                publicKey = listOf(
+                    PublicKeyEntry(
+                        id = "$did#owner",
+                        type = PublicKeyType.Secp256k1VerificationKey2018,
+                        owner = did,
+                        ethereumAddress = address
+                    )
+                ),
+                authentication = listOf(
+                    AuthenticationEntry(
+                        type = PublicKeyType.Secp256k1SignatureAuthentication2018,
+                        publicKey = "$did#owner"
+                    )
+                )
             )
         }
     }

--- a/jwt/build.gradle
+++ b/jwt/build.gradle
@@ -14,9 +14,15 @@ dependencies {
     api "com.github.komputing.kethereum:model:$kethereum_version"
     api "com.github.komputing.kethereum:crypto:$kethereum_version"
     api "com.github.komputing.kethereum:extensions:$kethereum_version"
+    implementation "com.github.komputing.kethereum:hashes:$kethereum_version"
+    implementation "com.github.komputing.kethereum:base58:$kethereum_version"
+    implementation "com.github.komputing.khex:extensions-jvm:$khex_version"
 
-    api "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
-    api "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
+    implementation "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
+    implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
+    implementation "com.github.uport-project.kotlin-common:signer-common:$uport_kotlin_common_version"
+    implementation "com.github.uport-project:kmnid:$kmnid_version"
+
     api project(":universal-did")
     api project(":uport-did")
     api project(":ethr-did")

--- a/jwt/build.gradle
+++ b/jwt/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     implementation "com.github.komputing.kethereum:base58:$kethereum_version"
 
     implementation "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
-    implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
-    implementation "com.github.uport-project.kotlin-common:signer-common:$uport_kotlin_common_version"
+    api "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
+    api "com.github.uport-project.kotlin-common:signer-common:$uport_kotlin_common_version"
     implementation "com.github.uport-project:kmnid:$kmnid_version"
 
     api project(":universal-did")

--- a/jwt/build.gradle
+++ b/jwt/build.gradle
@@ -11,12 +11,12 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
 
+    api "com.github.komputing.khex:extensions-jvm:$khex_version"
+    api "com.github.komputing.kethereum:extensions:$kethereum_version"
     api "com.github.komputing.kethereum:model:$kethereum_version"
     api "com.github.komputing.kethereum:crypto:$kethereum_version"
-    api "com.github.komputing.kethereum:extensions:$kethereum_version"
     implementation "com.github.komputing.kethereum:hashes:$kethereum_version"
     implementation "com.github.komputing.kethereum:base58:$kethereum_version"
-    implementation "com.github.komputing.khex:extensions-jvm:$khex_version"
 
     implementation "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
     implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -32,8 +32,8 @@ import org.kethereum.extensions.toBigInteger
 import org.kethereum.hashes.sha256
 import org.kethereum.model.PUBLIC_KEY_SIZE
 import org.kethereum.model.PublicKey
-import org.walleth.khex.clean0xPrefix
-import org.walleth.khex.hexToByteArray
+import org.komputing.khex.extensions.clean0xPrefix
+import org.komputing.khex.extensions.hexToByteArray
 import java.math.BigInteger
 import java.security.SignatureException
 import kotlin.math.floor

--- a/jwt/src/test/java/me/uport/sdk/jwt/KeyRecoveryTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/KeyRecoveryTest.kt
@@ -13,7 +13,7 @@ import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.extensions.toHexStringNoPrefix
 import org.kethereum.hashes.sha256
 import org.kethereum.model.PrivateKey
-import org.walleth.khex.toHexString
+import org.komputing.khex.extensions.toHexString
 
 class KeyRecoveryTest {
 

--- a/universal-did/build.gradle
+++ b/universal-did/build.gradle
@@ -9,7 +9,7 @@ project.ext.description = "wrapper for multiple DID resolvers"
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
-    api "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
 
     testImplementation "junit:junit:$junit_version"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"

--- a/uport-did/build.gradle
+++ b/uport-did/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     implementation "com.github.komputing.kethereum:base58:$kethereum_version"
 
     implementation "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
-    implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
+    api "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
     implementation "com.github.uport-project:kmnid:$kmnid_version"
 
     api project(":universal-did")

--- a/uport-did/build.gradle
+++ b/uport-did/build.gradle
@@ -14,9 +14,12 @@ dependencies {
     implementation "com.github.gnosis.bivrost-kotlin:bivrost-solidity-types:$bivrost_version"
 
     api "com.github.komputing.kethereum:extensions:$kethereum_version"
+    implementation "com.github.komputing.KEthereum:base58:$kethereum_version"
+    api "com.github.komputing.KHex:extensions-jvm:$khex_version"
 
-    api "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
-    api "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
+    implementation "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
+    implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
+    implementation "com.github.uport-project:kmnid:$kmnid_version"
 
     api project(":universal-did")
 

--- a/uport-did/build.gradle
+++ b/uport-did/build.gradle
@@ -13,9 +13,9 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
     implementation "com.github.gnosis.bivrost-kotlin:bivrost-solidity-types:$bivrost_version"
 
+    api "com.github.komputing.khex:extensions-jvm:$khex_version"
     api "com.github.komputing.kethereum:extensions:$kethereum_version"
-    implementation "com.github.komputing.KEthereum:base58:$kethereum_version"
-    api "com.github.komputing.KHex:extensions-jvm:$khex_version"
+    implementation "com.github.komputing.kethereum:base58:$kethereum_version"
 
     implementation "com.github.uport-project.kotlin-common:jsonrpc:$uport_kotlin_common_version"
     implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"

--- a/uport-did/src/main/java/me/uport/sdk/uportdid/UportIdentityDocument.kt
+++ b/uport-did/src/main/java/me/uport/sdk/uportdid/UportIdentityDocument.kt
@@ -13,7 +13,7 @@ import me.uport.sdk.universaldid.PublicKeyType.Companion.Curve25519EncryptionPub
 import me.uport.sdk.universaldid.PublicKeyType.Companion.Secp256k1SignatureAuthentication2018
 import me.uport.sdk.universaldid.PublicKeyType.Companion.Secp256k1VerificationKey2018
 import me.uport.sdk.uportdid.UportDIDResolver.Companion.parseDIDString
-import org.walleth.khex.clean0xPrefix
+import org.komputing.khex.extensions.clean0xPrefix
 
 /**
  * A class that encapsulates the legacy uport-did profile document

--- a/uport-did/src/test/java/me/uport/sdk/uportdid/UportDIDResolverTest.kt
+++ b/uport-did/src/test/java/me/uport/sdk/uportdid/UportDIDResolverTest.kt
@@ -19,7 +19,7 @@ import me.uport.sdk.jsonrpc.JsonRPC
 import me.uport.sdk.universaldid.PublicKeyType.Companion.Curve25519EncryptionPublicKey
 import me.uport.sdk.universaldid.PublicKeyType.Companion.Secp256k1VerificationKey2018
 import org.junit.Test
-import org.walleth.khex.clean0xPrefix
+import org.komputing.khex.extensions.clean0xPrefix
 
 class UportDIDResolverTest {
 
@@ -116,7 +116,7 @@ class UportDIDResolverTest {
             name = null
         )
 
-        val ddo = UportDIDResolver(rpc).getProfileDocumentFor(mnid = "2ozs2ntCXceKkAQKX4c9xp2zPS8pvkJhVqC")
+        val ddo = UportDIDResolver(rpc, http).getProfileDocumentFor(mnid = "2ozs2ntCXceKkAQKX4c9xp2zPS8pvkJhVqC")
 
         assertThat(ddo).isEqualTo(expectedDDO)
     }

--- a/web-did/build.gradle
+++ b/web-did/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
 
-    api "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
+    implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
     api project(":universal-did")
 
     testImplementation "junit:junit:$junit_version"

--- a/web-did/build.gradle
+++ b/web-did/build.gradle
@@ -18,4 +18,5 @@ dependencies {
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
     testImplementation "com.github.uport-project.kotlin-common:test-helpers:$uport_kotlin_common_version"
+    testImplementation "com.squareup.okhttp3:okhttp:$okhttp_version"
 }

--- a/web-did/build.gradle
+++ b/web-did/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
 
-    implementation "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
+    api "com.github.uport-project.kotlin-common:core:$uport_kotlin_common_version"
     api project(":universal-did")
 
     testImplementation "junit:junit:$junit_version"

--- a/web-did/src/test/java/me/uport/sdk/httpsdid/WebDIDResolverTest.kt
+++ b/web-did/src/test/java/me/uport/sdk/httpsdid/WebDIDResolverTest.kt
@@ -19,24 +19,24 @@ class WebDIDResolverTest {
 
     //language=json
     private val exampleDidDocString = """{
-      "@context": "https://w3id.org/did/v1",
-      "id": "did:web:example.com",
-      "publicKey": [
-        {
-          "id": "did:web:example.com#owner",
-          "type": "Secp256k1VerificationKey2018",
-          "owner": "did:web:example.com",
-          "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
-        }
-      ],
-      "authentication": [
-        {
-          "type": "Secp256k1SignatureAuthentication2018",
-          "publicKey": "did:web:example.com#owner"
-        }
-      ],
-      "service": []
-    }""".trimIndent()
+  "@context": "https://w3id.org/did/v1",
+  "id": "did:web:uport.me",
+  "publicKey": [
+    {
+      "id": "did:web:uport.me#owner",
+      "type": "Secp256k1VerificationKey2018",
+      "owner": "did:web:uport.me",
+      "publicKeyHex": "042b0af9b3ae6c7c3a90b01a3879d9518081bc0dcdf038488db9cb109b082a77d97ea3373e3dfde0eccd9adbdce11d0302ea5c098dbb0b310234c86895c8641622"
+    }
+  ],
+  "authentication": [
+    {
+      "type": "Secp256k1SignatureAuthentication2018",
+      "publicKey": "did:web:uport.me#owner"
+    }
+  ],
+  "service": []
+}""".trimIndent()
 
     private val exampleDidDoc = DIDDocumentImpl(
         context = "https://w3id.org/did/v1",
@@ -103,24 +103,25 @@ class WebDIDResolverTest {
     }
 
     @Test
-    fun `fails when the endpoint doesn't provide a DID document for deprecated https method`() = runBlocking {
-        val http = mockk<HttpClient>()
-        val tested = WebDIDResolver(http)
-        coEvery { http.urlGet(any()) } returns ""
+    fun `fails when the endpoint doesn't provide a DID document for deprecated https method`() =
+        runBlocking {
+            val http = mockk<HttpClient>()
+            val tested = WebDIDResolver(http)
+            coEvery { http.urlGet(any()) } returns ""
 
-        coAssert {
-            tested.resolve("did:https:example.com")
-        }.thrownError {
-            isInstanceOf(
-                listOf(
-                    IllegalArgumentException::class,
-                    IOException::class,
-                    SerializationException::class,
-                    DidResolverError::class
+            coAssert {
+                tested.resolve("did:https:example.com")
+            }.thrownError {
+                isInstanceOf(
+                    listOf(
+                        IllegalArgumentException::class,
+                        IOException::class,
+                        SerializationException::class,
+                        DidResolverError::class
+                    )
                 )
-            )
+            }
         }
-    }
 
     @Test
     fun `resolves document for deprecated https method`() = runBlocking {

--- a/web-did/src/test/java/me/uport/sdk/httpsdid/WebDIDResolverTest.kt
+++ b/web-did/src/test/java/me/uport/sdk/httpsdid/WebDIDResolverTest.kt
@@ -40,19 +40,19 @@ class WebDIDResolverTest {
 
     private val exampleDidDoc = DIDDocumentImpl(
         context = "https://w3id.org/did/v1",
-        id = "did:web:example.com",
+        id = "did:web:uport.me",
         publicKey = listOf(
             PublicKeyEntry(
-                id = "did:web:example.com#owner",
+                id = "did:web:uport.me#owner",
                 type = PublicKeyType.Secp256k1VerificationKey2018,
-                owner = "did:web:example.com",
-                publicKeyHex = "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
+                owner = "did:web:uport.me",
+                publicKeyHex = "042b0af9b3ae6c7c3a90b01a3879d9518081bc0dcdf038488db9cb109b082a77d97ea3373e3dfde0eccd9adbdce11d0302ea5c098dbb0b310234c86895c8641622"
             )
         ),
         authentication = listOf(
             AuthenticationEntry(
                 type = PublicKeyType.Secp256k1SignatureAuthentication2018,
-                publicKey = "did:web:example.com#owner"
+                publicKey = "did:web:uport.me#owner"
             )
         ),
         service = emptyList()


### PR DESCRIPTION
This PR updates kethereum to 0.76.1 and the kotlin-common libs to 0.3.x
Because of downstream breaking changes, some dependency have to be explicitly declared now and some imports had to be adapted.

No functionality change was made, all tests were kept.