### PR TITLE
bugfix: resolve publicKey entries with null chars in their names

### DIFF
--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -247,7 +247,7 @@ open class EthrDIDResolver : DIDResolver {
         )
     }
 
-    private fun processAttributeChanged(
+    internal fun processAttributeChanged(
         event: DIDAttributeChanged.Arguments,
         delegateCount: Int,
         normalizedDid: String
@@ -260,7 +260,7 @@ open class EthrDIDResolver : DIDResolver {
         if (validTo < _timeProvider.nowMs() / 1000L) {
             return (pkEntries to serviceEntries)
         }
-        val name = event.name.byteArray.bytes32ToString()
+        val name = event.name.byteArray.bytes32ToString().replace("\u0000", "")
         val key = "DIDAttributeChanged-$name-${event.value.items.toHexString()}"
 
         //language=RegExp


### PR DESCRIPTION
This fixes #26

The entries were being ignored because the string containing null chars was not matching the regex used to extract the attribute details.

A test was added to validate this scenario