### PR TITLE
Verify JWT using local DIDResolver

### DIFF
--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -409,6 +409,14 @@ class JWTTools(
      * entries in the DIDDocument
      *
      */
+    @Deprecated(
+        "Verifying a jwt token using the Universal Resolver is deprecated " +
+                "in favor of using a local resolver passed in as a method parameter." +
+                "This will be removed in the next major release.",
+        ReplaceWith(
+            """resolveAuthenticator(alg: String, issuer: String, auth: Boolean, resolver: DIDResolver)"""
+        )
+    )
     internal suspend fun resolveAuthenticator(alg: String, issuer: String, auth: Boolean): List<PublicKeyEntry> {
 
         if (alg !in verificationMethod.keys) {
@@ -453,6 +461,5 @@ class JWTTools(
             EcdsaPublicKeySecp256k1
         )
     }
-
 }
 

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -242,6 +242,14 @@ class JWTTools(
      *          , when the `audience` does not match the intended audience (`aud` field)
      * @return a [JwtPayload] if the verification is successful and `null` if it fails
      */
+    @Deprecated(
+        "Verifying a jwt token using the Universal Resolver is deprecated " +
+                "in favor of using a local resolver passed in as a method parameter." +
+                "This will be removed in the next major release.",
+        ReplaceWith(
+            """verify(token: String, auth: Boolean = false, audience: String? = null, resolver: DIDResolver)"""
+        )
+    )
     suspend fun verify(
         token: String,
         auth: Boolean = false,

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -330,9 +330,9 @@ class JWTTools(
      */
     suspend fun verify(
         token: String,
+        resolver: DIDResolver,
         auth: Boolean = false,
-        audience: String? = null,
-        resolver: DIDResolver
+        audience: String? = null
     ): JwtPayload {
         val (header, payload, signatureBytes) = decode(token)
 

--- a/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
+++ b/jwt/src/main/java/me/uport/sdk/jwt/JWTTools.kt
@@ -433,49 +433,6 @@ class JWTTools(
      * @param [auth] decide if the returned list should also be filtered against the `authentication`
      * entries in the DIDDocument
      *
-     */
-    @Suppress("DEPRECATION")
-    @Deprecated(
-        "Verifying a jwt token using the Universal Resolver is deprecated " +
-                "in favor of using a local resolver passed in as a method parameter." +
-                "This will be removed in the next major release.",
-        ReplaceWith(
-            """resolveAuthenticator(alg: String, issuer: String, auth: Boolean, resolver: DIDResolver)"""
-        )
-    )
-    internal suspend fun resolveAuthenticator(alg: String, issuer: String, auth: Boolean): List<PublicKeyEntry> {
-
-        if (alg !in verificationMethod.keys) {
-            throw JWTEncodingException("JWT algorithm '$alg' not supported")
-        }
-
-        val doc: DIDDocument = UniversalDID.resolve(issuer)
-
-        val authenticationKeys: List<String> = if (auth) {
-            doc.authentication.map { it.publicKey }
-        } else {
-            emptyList() // return an empty list
-        }
-
-        val authenticators = doc.publicKey.filter {
-
-            // filter public keys which belong to the list of supported key types
-            supportedKeyTypes.contains(it.type) && (!auth || (authenticationKeys.contains(it.id)))
-        }
-
-        if (auth && (authenticators.isEmpty())) throw InvalidJWTException("DID document for $issuer does not have public keys suitable for authenticating user")
-        if (authenticators.isEmpty()) throw InvalidJWTException("DID document for $issuer does not have public keys for $alg")
-
-        return authenticators
-    }
-
-    /**
-     * This method obtains a [DIDDocument] corresponding to the [issuer] and returns a list of [PublicKeyEntry]
-     * that can be used to check JWT signatures
-     *
-     * @param [auth] decide if the returned list should also be filtered against the `authentication`
-     * entries in the DIDDocument
-     *
      * @param [resolver] the resolver that should be used locally in the verify method to resolve the DIDs.
      *
      */

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -6,6 +6,7 @@ import io.mockk.coEvery
 import io.mockk.mockkObject
 import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
+import me.uport.sdk.core.Networks
 import me.uport.sdk.ethrdid.EthrDIDDocument
 import me.uport.sdk.ethrdid.EthrDIDNetwork
 import me.uport.sdk.ethrdid.EthrDIDResolver
@@ -18,6 +19,7 @@ import me.uport.sdk.testhelpers.TestTimeProvider
 import me.uport.sdk.testhelpers.coAssert
 import me.uport.sdk.universaldid.UniversalDID
 import me.uport.sdk.uportdid.UportDIDDocument
+import me.uport.sdk.uportdid.UportDIDResolver
 import org.junit.Test
 
 class JWTToolsJVMTest {
@@ -27,8 +29,10 @@ class JWTToolsJVMTest {
         "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1MzUwMTY1OTcsImV4cCI6MTUzNTEwMjk5NywiYXVkIjoiZGlkOmV0aHI6MHhhOWUzMjMyYjYxYmRiNjcyNzEyYjlhZTMzMTk1MDY5ZDhkNjUxYzFhIiwidHlwZSI6InNoYXJlUmVzcCIsIm5hZCI6IjJvd2hGdGRtc0VVNVVWMVNCbld0RnZZcHlUcjNqNHd5TmR2Iiwib3duIjp7Im5hbWUiOiJ1UG9ydCBVc2VyIn0sInJlcSI6ImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSkZVekkxTmtzdFVpSjkuZXlKcFlYUWlPakUxTXpVd01UWTFPRGdzSW1WNGNDSTZNVFV6TlRBeE56RTRPQ3dpY21WeGRXVnpkR1ZrSWpwYkltNWhiV1VpTENKd2FHOXVaU0lzSW1OdmRXNTBjbmtpWFN3aWNHVnliV2x6YzJsdmJuTWlPbHNpYm05MGFXWnBZMkYwYVc5dWN5SmRMQ0pqWVd4c1ltRmpheUk2SW1oMGRIQnpPaTh2WTJoaGMzRjFhUzUxY0c5eWRDNXRaUzloY0drdmRqRXZkRzl3YVdNdldtMXNOa2xuUWsxYU9XUXhWbGgwV0ZsYVJUTlBkeUlzSW1GamRDSTZJbXRsZVhCaGFYSWlMQ0owZVhCbElqb2ljMmhoY21WU1pYRWlMQ0pwYzNNaU9pSmthV1E2WlhSb2Nqb3dlR0U1WlRNeU16SmlOakZpWkdJMk56STNNVEppT1dGbE16TXhPVFV3Tmpsa09HUTJOVEZqTVdFaWZRLnRNbWh6cjFkbER0YUhUeWUtVDAxOGp2N0NUYlRhVWY4ZzlhbHNxVWJ6VGpGUkFsbV9qZ2RaR3pVVEVzeGtBY0ZmVy1ZSmpIVGtwSmtjNFNWREc3REJBQSIsImlzcyI6ImRpZDpldGhyOjB4ZThjOTFiZGU3NjI1YWIyYzBlZDlmMjE0ZGViMzk0NDBkYTdlMDNjNCJ9.-04Z_m2kgFBwF1Elh3jmv1_44jdGjEczf4x3c5Z4TxwiMP8nXZsIDVgsp3PS34DPGfpR4OkZ6LBozBBER3TABAA"
     )
 
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+            "This will be removed in the next major release.")
     @Test
-    fun `verifies simple tokens`() = runBlocking {
+    fun `verifies simple tokens (deprecated)`() = runBlocking {
         mockkObject(UniversalDID)
 
         coEvery { UniversalDID.resolve("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154") }.returns(
@@ -45,6 +49,36 @@ class JWTToolsJVMTest {
         tokens.forEach { token ->
             val payload = JWTTools(TestTimeProvider(1535102500000L)).verify(
                 token = token,
+                audience = "did:ethr:0xa9e3232b61bdb672712b9ae33195069d8d651c1a"
+            )
+            assertThat(payload).isNotNull()
+        }
+    }
+
+    @Test
+    fun `verifies simple tokens`() = runBlocking {
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        coEvery { resolver.resolve("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154") }.returns(
+            EthrDIDDocument.fromJson(
+                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
+            )
+        )
+        coEvery { resolver.resolve("did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4") }.returns(
+            EthrDIDDocument.fromJson(
+                """{"id":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4","publicKey":[{"id":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4","ethereumAddress":"0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
+            )
+        )
+
+        tokens.forEach { token ->
+            val payload = JWTTools(TestTimeProvider(1535102500000L)).verify(
+                token = token,
+                resolver = resolver,
                 audience = "did:ethr:0xa9e3232b61bdb672712b9ae33195069d8d651c1a"
             )
             assertThat(payload).isNotNull()
@@ -107,8 +141,10 @@ class JWTToolsJVMTest {
         acc = null
     )
 
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+            "This will be removed in the next major release.")
     @Test
-    fun `returns correct payload after successful verification`() = runBlocking {
+    fun `returns correct payload after successful verification (deprecated)`() = runBlocking {
         mockkObject(UniversalDID)
 
         coEvery { UniversalDID.resolve("2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG") }.returns(UportDIDDocument.fromJson("""{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKey":[{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1","type":"Secp256k1VerificationKey2018","owner":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKeyHex":"04171fcc7654cad14745b9835bc534d8e59038ae6929c793d7f8dd2c934580ca39ff1e2de3d7ef69a8daba5e5590d3ec80486a273cbe2bd1b76ebd01f949b41463"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/Qmez4bdFmxPknbAoGzHmpjpLjQFChq39h5UMPGiwUHgt8f"},"name":"uPort Demo","description":"Demo App"}}"""))
@@ -118,6 +154,30 @@ class JWTToolsJVMTest {
         assertThat(shareReqPayload).isEqualTo(expectedShareReqPayload1)
 
         val incomingJwtPayload = JWTTools(TestTimeProvider(1522540300000L)).verify(incomingJwt)
+        assertThat(incomingJwtPayload).isEqualTo(expectedJwtPayload)
+    }
+
+    @Test
+    fun `returns correct payload after successful verification`() = runBlocking {
+
+        val resolver = UportDIDResolver(JsonRPC(Networks.rinkeby.rpcUrl))
+
+        coEvery {
+            resolver.resolve("2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG")
+        }.returns(
+            UportDIDDocument.fromJson("""{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKey":[{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1","type":"Secp256k1VerificationKey2018","owner":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKeyHex":"04171fcc7654cad14745b9835bc534d8e59038ae6929c793d7f8dd2c934580ca39ff1e2de3d7ef69a8daba5e5590d3ec80486a273cbe2bd1b76ebd01f949b41463"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/Qmez4bdFmxPknbAoGzHmpjpLjQFChq39h5UMPGiwUHgt8f"},"name":"uPort Demo","description":"Demo App"}}""")
+        )
+
+        coEvery {
+            resolver.resolve("2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf")
+        }.returns(
+            UportDIDDocument.fromJson("""{"id":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf","publicKey":[{"id":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf#keys-1","type":"Secp256k1VerificationKey2018","owner":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf","publicKeyHex":"0422d2edad30d8588c0661e032f37af8177cfa0a056ee9b8ca953b07c6600a637c002ed22fe6612e28e558aee130d399ba97f89e25c16661a99c8af8c832b88568"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/QmdznPoNSnc6RawSzzvNFX5HerF62Vu7sbP3vSur9gDFGb"},"name":"Olorun","description":"Private network configuration service"}}""")
+        )
+
+        val shareReqPayload = JWTTools(TestTimeProvider(1520366666000L)).verify(validShareReqToken1, resolver)
+        assertThat(shareReqPayload).isEqualTo(expectedShareReqPayload1)
+
+        val incomingJwtPayload = JWTTools(TestTimeProvider(1522540300000L)).verify(incomingJwt, resolver)
         assertThat(incomingJwtPayload).isEqualTo(expectedJwtPayload)
     }
 
@@ -136,8 +196,10 @@ class JWTToolsJVMTest {
         }
     }
 
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+            "This will be removed in the next major release.")
     @Test
-    fun `throws error when aud is not available`() = runBlocking {
+    fun `throws error when aud is not available (deprecated)`() = runBlocking {
         mockkObject(UniversalDID)
 
         val token =
@@ -159,7 +221,37 @@ class JWTToolsJVMTest {
     }
 
     @Test
-    fun `throws error when aud and payload aud do not match`() = runBlocking {
+    fun `throws error when aud is not available`() = runBlocking {
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        val token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1MzUwMTY3MDIsImV4cCI6MTUzNTEwMzEwMiwiYXVkIjoiZGlkOmV0aHI6MHhhOWUzMjMyYjYxYmRiNjcyNzEyYjlhZTMzMTk1MDY5ZDhkNjUxYzFhIiwidHlwZSI6InNoYXJlUmVzcCIsIm5hZCI6IjJvZHpqVGFpOFJvNFYzS3hrbTNTblppdjlXU1l1Tm9aNEFoIiwib3duIjp7Im5hbWUiOiJ1UG9ydCBVc2VyIn0sInJlcSI6ImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSkZVekkxTmtzdFVpSjkuZXlKcFlYUWlPakUxTXpVd01UWTJPREVzSW1WNGNDSTZNVFV6TlRBeE56STRNU3dpY21WeGRXVnpkR1ZrSWpwYkltNWhiV1VpTENKd2FHOXVaU0lzSW1OdmRXNTBjbmtpWFN3aWNHVnliV2x6YzJsdmJuTWlPbHNpYm05MGFXWnBZMkYwYVc5dWN5SmRMQ0pqWVd4c1ltRmpheUk2SW1oMGRIQnpPaTh2WTJoaGMzRjFhUzUxY0c5eWRDNXRaUzloY0drdmRqRXZkRzl3YVdNdmJVVXpTbVpXZWxOMFNuUnFhbnBvWWpSYVRFRnhkeUlzSW1GamRDSTZJbXRsZVhCaGFYSWlMQ0owZVhCbElqb2ljMmhoY21WU1pYRWlMQ0pwYzNNaU9pSmthV1E2WlhSb2Nqb3dlR0U1WlRNeU16SmlOakZpWkdJMk56STNNVEppT1dGbE16TXhPVFV3Tmpsa09HUTJOVEZqTVdFaWZRLnVScUdGd01XNnpWSDR4OWFmTDAtS29qSEYwVF9GbW9QWnR6OG5uSjRFXzhNY2cxejBBZ21aMnplOE5iS05wVUNnRHRwTU9RNzVGSjU4WmhzbWFxQUxBRSIsImNhcGFiaWxpdGllcyI6WyJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpGVXpJMU5rc3RVaUo5LmV5SnBZWFFpT2pFMU16VXdNVFkzTURFc0ltVjRjQ0k2TVRVek5qTXhNamN3TVN3aVlYVmtJam9pWkdsa09tVjBhSEk2TUhoaE9XVXpNak15WWpZeFltUmlOamN5TnpFeVlqbGhaVE16TVRrMU1EWTVaRGhrTmpVeFl6RmhJaXdpZEhsd1pTSTZJbTV2ZEdsbWFXTmhkR2x2Ym5NaUxDSjJZV3gxWlNJNkltRnlianBoZDNNNmMyNXpPblZ6TFhkbGMzUXRNam94TVRNeE9UWXlNVFkxTlRnNlpXNWtjRzlwYm5RdlIwTk5MM1ZRYjNKMEx6UXpNRGsxTWpZMkxUSmhPR1F0TTJFMFpTMWlaRFV3TFRka01USm1ZVE00TWpRNFlpSXNJbWx6Y3lJNkltUnBaRHBsZEdoeU9qQjRNVEE0TWpBNVpqUXlORGRpTjJabE5qWXdOV0l3WmpVNFpqa3hORFZsWXpNeU5qbGtNREUxTkNKOS5Lc0F6TmVDeHFDaF9rMkt4aTYtWHFveFNXZjBCLWFFR0xXdi1ldHVXQlF2QU5neDFTMG5oZ0ppRkllUnRXakw4ekdnVVV3MUlsSWJtYUZrOEo5aGdhd0UiXSwiYm94UHViIjoiY2g3aGI2S3hsakJ2bXh5UDJXZENWTFNTLzQ2S1hCcmdkWG1Mcm03VEpIST0iLCJpc3MiOiJkaWQ6ZXRocjoweDEwODIwOWY0MjQ3YjdmZTY2MDViMGY1OGY5MTQ1ZWMzMjY5ZDAxNTQifQ.Ncf8B_y0Ha8gdaYyCaL5jLX2RsKTMwxTQ8KlybXFygsxKUUQm9OXo4lU65fduIaFvVyPOP6Oe2adar8m0m2aiwA"
+
+        coEvery { resolver.resolve("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154") }.returns(
+            EthrDIDDocument.fromJson(
+                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
+            )
+        )
+
+        coAssert {
+            JWTTools(TestTimeProvider(1535102500000L)).verify(
+                token = token,
+                resolver = resolver
+            )
+        }.thrownError {
+            isInstanceOf(InvalidJWTException::class)
+        }
+    }
+
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+            "This will be removed in the next major release.")
+    @Test
+    fun `throws error when aud and payload aud do not match (deprecated)`() = runBlocking {
         mockkObject(UniversalDID)
 
         val token =
@@ -182,7 +274,38 @@ class JWTToolsJVMTest {
     }
 
     @Test
-    fun `throws when a token is issued in the future`() {
+    fun `throws error when aud and payload aud do not match`() = runBlocking {
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        val token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1MzUwMTY3MDIsImV4cCI6MTUzNTEwMzEwMiwiYXVkIjoiZGlkOmV0aHI6MHhhOWUzMjMyYjYxYmRiNjcyNzEyYjlhZTMzMTk1MDY5ZDhkNjUxYzFhIiwidHlwZSI6InNoYXJlUmVzcCIsIm5hZCI6IjJvZHpqVGFpOFJvNFYzS3hrbTNTblppdjlXU1l1Tm9aNEFoIiwib3duIjp7Im5hbWUiOiJ1UG9ydCBVc2VyIn0sInJlcSI6ImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSkZVekkxTmtzdFVpSjkuZXlKcFlYUWlPakUxTXpVd01UWTJPREVzSW1WNGNDSTZNVFV6TlRBeE56STRNU3dpY21WeGRXVnpkR1ZrSWpwYkltNWhiV1VpTENKd2FHOXVaU0lzSW1OdmRXNTBjbmtpWFN3aWNHVnliV2x6YzJsdmJuTWlPbHNpYm05MGFXWnBZMkYwYVc5dWN5SmRMQ0pqWVd4c1ltRmpheUk2SW1oMGRIQnpPaTh2WTJoaGMzRjFhUzUxY0c5eWRDNXRaUzloY0drdmRqRXZkRzl3YVdNdmJVVXpTbVpXZWxOMFNuUnFhbnBvWWpSYVRFRnhkeUlzSW1GamRDSTZJbXRsZVhCaGFYSWlMQ0owZVhCbElqb2ljMmhoY21WU1pYRWlMQ0pwYzNNaU9pSmthV1E2WlhSb2Nqb3dlR0U1WlRNeU16SmlOakZpWkdJMk56STNNVEppT1dGbE16TXhPVFV3Tmpsa09HUTJOVEZqTVdFaWZRLnVScUdGd01XNnpWSDR4OWFmTDAtS29qSEYwVF9GbW9QWnR6OG5uSjRFXzhNY2cxejBBZ21aMnplOE5iS05wVUNnRHRwTU9RNzVGSjU4WmhzbWFxQUxBRSIsImNhcGFiaWxpdGllcyI6WyJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpGVXpJMU5rc3RVaUo5LmV5SnBZWFFpT2pFMU16VXdNVFkzTURFc0ltVjRjQ0k2TVRVek5qTXhNamN3TVN3aVlYVmtJam9pWkdsa09tVjBhSEk2TUhoaE9XVXpNak15WWpZeFltUmlOamN5TnpFeVlqbGhaVE16TVRrMU1EWTVaRGhrTmpVeFl6RmhJaXdpZEhsd1pTSTZJbTV2ZEdsbWFXTmhkR2x2Ym5NaUxDSjJZV3gxWlNJNkltRnlianBoZDNNNmMyNXpPblZ6TFhkbGMzUXRNam94TVRNeE9UWXlNVFkxTlRnNlpXNWtjRzlwYm5RdlIwTk5MM1ZRYjNKMEx6UXpNRGsxTWpZMkxUSmhPR1F0TTJFMFpTMWlaRFV3TFRka01USm1ZVE00TWpRNFlpSXNJbWx6Y3lJNkltUnBaRHBsZEdoeU9qQjRNVEE0TWpBNVpqUXlORGRpTjJabE5qWXdOV0l3WmpVNFpqa3hORFZsWXpNeU5qbGtNREUxTkNKOS5Lc0F6TmVDeHFDaF9rMkt4aTYtWHFveFNXZjBCLWFFR0xXdi1ldHVXQlF2QU5neDFTMG5oZ0ppRkllUnRXakw4ekdnVVV3MUlsSWJtYUZrOEo5aGdhd0UiXSwiYm94UHViIjoiY2g3aGI2S3hsakJ2bXh5UDJXZENWTFNTLzQ2S1hCcmdkWG1Mcm03VEpIST0iLCJpc3MiOiJkaWQ6ZXRocjoweDEwODIwOWY0MjQ3YjdmZTY2MDViMGY1OGY5MTQ1ZWMzMjY5ZDAxNTQifQ.Ncf8B_y0Ha8gdaYyCaL5jLX2RsKTMwxTQ8KlybXFygsxKUUQm9OXo4lU65fduIaFvVyPOP6Oe2adar8m0m2aiwA"
+
+        coEvery { resolver.resolve("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154") }.returns(
+            EthrDIDDocument.fromJson(
+                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
+            )
+        )
+
+        coAssert {
+            JWTTools(TestTimeProvider(1535102500000L)).verify(
+                token = token,
+                resolver = resolver,
+                audience = "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154"
+            )
+        }.thrownError {
+            isInstanceOf(InvalidJWTException::class)
+        }
+    }
+
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+            "This will be removed in the next major release.")
+    @Test
+    fun `throws when a token is issued in the future (deprecated)`() {
         val token =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXRocjoweGE5ZTMyMzJiNjFiZGI2NzI3MTJiOWFlMzMxOTUwNjlkOGQ2NTFjMWEiLCJpYXQiOjE1NDU1Njk1NDEsImV4cCI6MTU0NjA4Nzk0MSwiYXVkIjoiZGlkOmV0aHI6MHgxMDgyMDlmNDI0N2I3ZmU2NjA1YjBmNThmOTE0NWVjMzI2OWQwMTU0Iiwic3ViIjoiIn0.Bt9Frc1QabJfpXYBoU4sns8WPeRLdKU87FncgMFq1lY"
 
@@ -194,7 +317,27 @@ class JWTToolsJVMTest {
     }
 
     @Test
-    fun `throws when a token is expired`() {
+    fun `throws when a token is issued in the future`() {
+        val token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXRocjoweGE5ZTMyMzJiNjFiZGI2NzI3MTJiOWFlMzMxOTUwNjlkOGQ2NTFjMWEiLCJpYXQiOjE1NDU1Njk1NDEsImV4cCI6MTU0NjA4Nzk0MSwiYXVkIjoiZGlkOmV0aHI6MHgxMDgyMDlmNDI0N2I3ZmU2NjA1YjBmNThmOTE0NWVjMzI2OWQwMTU0Iiwic3ViIjoiIn0.Bt9Frc1QabJfpXYBoU4sns8WPeRLdKU87FncgMFq1lY"
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        coAssert {
+            JWTTools(TestTimeProvider(977317692000L)).verify(token, resolver)
+        }.thrownError {
+            isInstanceOf(InvalidJWTException::class)
+        }
+    }
+
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+            "This will be removed in the next major release.")
+    @Test
+    fun `throws when a token is expired (deprecated)`() {
         val token =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXRocjoweGE5ZTMyMzJiNjFiZGI2NzI3MTJiOWFlMzMxOTUwNjlkOGQ2NTFjMWEiLCJpYXQiOjE1NDU1Njk1NDEsImV4cCI6MTU0NjA4Nzk0MSwiYXVkIjoiZGlkOmV0aHI6MHgxMDgyMDlmNDI0N2I3ZmU2NjA1YjBmNThmOTE0NWVjMzI2OWQwMTU0Iiwic3ViIjoiIn0.Bt9Frc1QabJfpXYBoU4sns8WPeRLdKU87FncgMFq1lY"
 
@@ -206,7 +349,27 @@ class JWTToolsJVMTest {
     }
 
     @Test
-    fun `throws when the signature does not match any public keys belonging to the issuer`() {
+    fun `throws when a token is expired`() {
+        val token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJkaWQ6ZXRocjoweGE5ZTMyMzJiNjFiZGI2NzI3MTJiOWFlMzMxOTUwNjlkOGQ2NTFjMWEiLCJpYXQiOjE1NDU1Njk1NDEsImV4cCI6MTU0NjA4Nzk0MSwiYXVkIjoiZGlkOmV0aHI6MHgxMDgyMDlmNDI0N2I3ZmU2NjA1YjBmNThmOTE0NWVjMzI2OWQwMTU0Iiwic3ViIjoiIn0.Bt9Frc1QabJfpXYBoU4sns8WPeRLdKU87FncgMFq1lY"
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        coAssert {
+            JWTTools(TestTimeProvider(1576847292000L)).verify(token, resolver)
+        }.thrownError {
+            isInstanceOf(InvalidJWTException::class)
+        }
+    }
+
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+            "This will be removed in the next major release.")
+    @Test
+    fun `throws when the signature does not match any public keys belonging to the issuer (deprecated)`() {
 
         mockkObject(UniversalDID)
         coEvery { UniversalDID.resolve("did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9") }.returns(
@@ -221,6 +384,32 @@ class JWTToolsJVMTest {
 
         coAssert {
             JWTTools(TestTimeProvider(1547818630000L)).verify(token)
+        }.thrownError {
+            isInstanceOf(InvalidJWTException::class)
+        }
+    }
+
+    @Test
+    fun `throws when the signature does not match any public keys belonging to the issuer`() {
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        coEvery { resolver.resolve("did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9") }.returns(
+            EthrDIDDocument.fromJson(
+                """{"id":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9","publicKey":[{"id":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9","ethereumAddress":"0x6985a110df37555235d7d0de0a0fb28c9848dfa9","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
+            )
+        )
+
+        // JWT token with a Signer that doesn't have anything to do with the issuerDID.
+        val token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NDY4NTkxNTksImV4cCI6MTg2MjIxOTE1OSwiaXNzIjoiZGlkOmV0aHI6MHg2OTg1YTExMGRmMzc1NTUyMzVkN2QwZGUwYTBmYjI4Yzk4NDhkZmE5In0.fe1rvAHsoJsJzwSFAmVFTz9uxhncNY65jpbb2cS9jcY08xphpU3rOy1N85_IbEjhIZw-FrPeFgxJLoDLw6itcgE"
+
+        coAssert {
+            JWTTools(TestTimeProvider(1547818630000L)).verify(token, resolver)
         }.thrownError {
             isInstanceOf(InvalidJWTException::class)
         }
@@ -403,8 +592,10 @@ class JWTToolsJVMTest {
         }
     }
 
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+            "This will be removed in the next major release.")
     @Test
-    fun `can verify a freshly minted token`() = runBlocking {
+    fun `can verify a freshly minted token (deprecated)`() = runBlocking {
         val signer = KPSigner("0x1234")
         val did = "did:ethr:${signer.getAddress()}"
 
@@ -426,7 +617,29 @@ class JWTToolsJVMTest {
     }
 
     @Test
-    fun `can verify a ES256K signature with only ethereumAddress in the DID doc`() = runBlocking {
+    fun `can verify a freshly minted token`() = runBlocking {
+        val signer = KPSigner("0x1234")
+        val did = "did:ethr:${signer.getAddress()}"
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        coEvery { resolver.resolve(eq(did)) } returns
+                EthrDIDTestHelpers.mockDocForAddress(signer.getAddress())
+
+        val token = JWTTools().createJWT(emptyMap(), did, signer)
+        val payload = JWTTools().verify(token, resolver)
+        assertThat(payload).isNotNull()
+        Unit
+    }
+
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+                            "This will be removed in the next major release.")
+    @Test
+    fun `can verify a ES256K signature with only ethereumAddress in the DID doc (deprecated)`() = runBlocking {
         val address = "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed"
 
         val resolver = spyk(
@@ -443,6 +656,25 @@ class JWTToolsJVMTest {
         val token =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNTYxOTcxMTE5LCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.t5o1vzZExArlrrTVHmwtti7fnicXqvWrX6SS3F-Lu3budH7p6zQHjG8X7EvUTRUxhvr-eENCbXeteSE4rgF7MA"
         val payload = JWTTools().verify(token)
+        assertThat(payload.iss).isEqualTo("did:ethr:$address")
+    }
+
+    @Test
+    fun `can verify a ES256K signature with only ethereumAddress in the DID doc`() = runBlocking {
+        val address = "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed"
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        coEvery { resolver.resolve(eq("did:ethr:$address")) } returns
+                EthrDIDTestHelpers.mockDocForAddress(address)
+
+        val token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJoZWxsbyI6IndvcmxkIiwiaWF0IjoxNTYxOTcxMTE5LCJpc3MiOiJkaWQ6ZXRocjoweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.t5o1vzZExArlrrTVHmwtti7fnicXqvWrX6SS3F-Lu3budH7p6zQHjG8X7EvUTRUxhvr-eENCbXeteSE4rgF7MA"
+        val payload = JWTTools().verify(token, resolver)
         assertThat(payload.iss).isEqualTo("did:ethr:$address")
     }
 

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -414,39 +414,6 @@ class JWTToolsJVMTest {
         }
     }
 
-    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
-            "This will be removed in the next major release.")
-    @Test
-    fun `finds public key (deprecated)`() = runBlocking {
-
-        val alg = "ES256K"
-        val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
-        val auth = false
-        val doc = EthrDIDDocument.fromJson(
-            """
-                    {
-                        "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                        "publicKey": [{
-                            "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1",
-                            "type": "Secp256k1VerificationKey2018",
-                            "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                            "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
-                        }],
-                        "authentication": [],
-                        "service": [],
-                        "@context": "https://w3id.org/did/v1"
-                    }
-                    """
-        )
-
-        mockkObject(UniversalDID)
-
-        coEvery { UniversalDID.resolve(issuer) }.returns(doc)
-
-        val authenticators = JWTTools().resolveAuthenticator(alg, issuer, auth)
-        assertThat(authenticators).isEqualTo(doc.publicKey)
-    }
-
 
     @Test
     fun `finds public key`() = runBlocking {
@@ -481,61 +448,6 @@ class JWTToolsJVMTest {
 
         val authenticators = JWTTools().resolveAuthenticator(alg, issuer, auth, resolver)
         assertThat(authenticators).isEqualTo(doc.publicKey)
-    }
-
-    @Deprecated("This test references the deprecated variant of JWTTools().resolveAuthenticator()" +
-            "This will be removed in the next major release.")
-    @Test
-    fun `only list authenticators able to authenticate a user (deprecated)`() = runBlocking {
-
-        val alg = "ES256K"
-        val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
-        val auth = true
-        val doc = EthrDIDDocument.fromJson(
-            """
-            {
-                "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                "publicKey": [{
-                    "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1",
-                    "type": "Secp256k1VerificationKey2018",
-                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                    "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
-                }, {
-                    "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-2",
-                    "type": "Secp256k1SignatureVerificationKey2018",
-                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                    "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
-                }, {
-                    "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-3",
-                    "type": "Secp256k1SignatureAuthentication2018",
-                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                    "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
-                }, {
-                    "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-3",
-                    "type": "Curve25519EncryptionPublicKey",
-                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                    "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
-                }],
-                "authentication": [{
-                    "type": "Secp256k1VerificationKey2018",
-                    "publicKey": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1"
-                }, {
-                    "type": "Secp256k1SignatureVerificationKey2018",
-                    "publicKey": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-2"
-                }],
-                "service": [],
-                "@context": "https://w3id.org/did/v1"
-            }
-            """
-        )
-
-        mockkObject(UniversalDID)
-
-        coEvery { UniversalDID.resolve(issuer) }.returns(doc)
-
-        val authenticators = JWTTools().resolveAuthenticator(alg, issuer, auth)
-
-        assertThat(authenticators).isEqualTo(listOf(doc.publicKey[0], doc.publicKey[1]))
     }
 
 
@@ -596,41 +508,6 @@ class JWTToolsJVMTest {
         assertThat(authenticators).isEqualTo(listOf(doc.publicKey[0], doc.publicKey[1]))
     }
 
-    @Deprecated("This test references the deprecated variant of JWTTools().resolveAuthenticator()" +
-            "This will be removed in the next major release.")
-    @Test
-    fun `errors if no suitable public keys exist for authentication (deprecated)`() = runBlocking {
-
-        val alg = "ES256K"
-        val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
-        val auth = true
-        val doc = EthrDIDDocument.fromJson(
-            """
-                    {
-                        "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                        "publicKey": [{
-                            "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1",
-                            "type": "Secp256k1VerificationKey2018",
-                            "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                            "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
-                        }],
-                        "authentication": [],
-                        "service": [],
-                        "@context": "https://w3id.org/did/v1"
-                    }
-                    """
-        )
-
-        mockkObject(UniversalDID)
-
-        coEvery { UniversalDID.resolve(issuer) }.returns(doc)
-
-        coAssert {
-            JWTTools().resolveAuthenticator(alg, issuer, auth)
-        }.thrownError {
-            isInstanceOf(InvalidJWTException::class)
-        }
-    }
 
     @Test
     fun `errors if no suitable public keys exist for authentication`() = runBlocking {
@@ -676,36 +553,6 @@ class JWTToolsJVMTest {
         }
     }
 
-    @Deprecated("This test references the deprecated variant of JWTTools().resolveAuthenticator()" +
-            "This will be removed in the next major release.")
-    @Test
-    fun `errors if no public keys exist (deprecated)`() = runBlocking {
-
-        val alg = "ES256K"
-        val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
-        val auth = false
-        val doc = EthrDIDDocument.fromJson(
-            """
-                    {
-                        "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                        "publicKey": [],
-                        "authentication": [],
-                        "service": [],
-                        "@context": "https://w3id.org/did/v1"
-                    }
-                    """
-        )
-
-        mockkObject(UniversalDID)
-
-        coEvery { UniversalDID.resolve(issuer) }.returns(doc)
-
-        coAssert {
-            JWTTools().resolveAuthenticator(alg, issuer, auth)
-        }.thrownError {
-            isInstanceOf(InvalidJWTException::class)
-        }
-    }
 
     @Test
     fun `errors if no public keys exist`() = runBlocking {
@@ -743,37 +590,6 @@ class JWTToolsJVMTest {
             JWTTools().resolveAuthenticator(alg, issuer, auth, resolver)
         }.thrownError {
             isInstanceOf(InvalidJWTException::class)
-        }
-    }
-
-    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
-            "This will be removed in the next major release.")
-    @Test
-    fun `errors if no supported signature types exist (deprecated)`() = runBlocking {
-
-        val alg = "ESBAD"
-        val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
-        val auth = false
-        val doc = EthrDIDDocument.fromJson(
-            """
-                    {
-                        "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
-                        "publicKey": [],
-                        "authentication": [],
-                        "service": [],
-                        "@context": "https://w3id.org/did/v1"
-                    }
-                    """
-        )
-
-        mockkObject(UniversalDID)
-
-        coEvery { UniversalDID.resolve(issuer) }.returns(doc)
-
-        coAssert {
-            JWTTools().resolveAuthenticator(alg, issuer, auth)
-        }.thrownError {
-            isInstanceOf(JWTEncodingException::class)
         }
     }
 

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -6,7 +6,6 @@ import io.mockk.coEvery
 import io.mockk.mockkObject
 import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
-import me.uport.sdk.core.Networks
 import me.uport.sdk.ethrdid.EthrDIDDocument
 import me.uport.sdk.ethrdid.EthrDIDNetwork
 import me.uport.sdk.ethrdid.EthrDIDResolver
@@ -160,7 +159,7 @@ class JWTToolsJVMTest {
     @Test
     fun `returns correct payload after successful verification`() = runBlocking {
 
-        val resolver = UportDIDResolver(JsonRPC(Networks.rinkeby.rpcUrl))
+        val resolver = spyk(UportDIDResolver(JsonRPC("")))
 
         coEvery {
             resolver.resolve("2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG")

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -414,9 +414,10 @@ class JWTToolsJVMTest {
         }
     }
 
-
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+            "This will be removed in the next major release.")
     @Test
-    fun `finds public key`() = runBlocking {
+    fun `finds public key (deprecated)`() = runBlocking {
 
         val alg = "ES256K"
         val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
@@ -446,8 +447,46 @@ class JWTToolsJVMTest {
         assertThat(authenticators).isEqualTo(doc.publicKey)
     }
 
+
     @Test
-    fun `only list authenticators able to authenticate a user`() = runBlocking {
+    fun `finds public key`() = runBlocking {
+
+        val alg = "ES256K"
+        val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
+        val auth = false
+        val doc = EthrDIDDocument.fromJson(
+            """
+                    {
+                        "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                        "publicKey": [{
+                            "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                            "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
+                        }],
+                        "authentication": [],
+                        "service": [],
+                        "@context": "https://w3id.org/did/v1"
+                    }
+                    """
+        )
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "", JsonRPC("")))
+                .build()
+        )
+
+        coEvery { resolver.resolve(issuer) }.returns(doc)
+
+        val authenticators = JWTTools().resolveAuthenticator(alg, issuer, auth, resolver)
+        assertThat(authenticators).isEqualTo(doc.publicKey)
+    }
+
+    @Deprecated("This test references the deprecated variant of JWTTools().resolveAuthenticator()" +
+            "This will be removed in the next major release.")
+    @Test
+    fun `only list authenticators able to authenticate a user (deprecated)`() = runBlocking {
 
         val alg = "ES256K"
         val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
@@ -499,6 +538,100 @@ class JWTToolsJVMTest {
         assertThat(authenticators).isEqualTo(listOf(doc.publicKey[0], doc.publicKey[1]))
     }
 
+
+    @Test
+    fun `only list authenticators able to authenticate a user`() = runBlocking {
+
+        val alg = "ES256K"
+        val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
+        val auth = true
+        val doc = EthrDIDDocument.fromJson(
+            """
+            {
+                "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                "publicKey": [{
+                    "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1",
+                    "type": "Secp256k1VerificationKey2018",
+                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                    "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
+                }, {
+                    "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-2",
+                    "type": "Secp256k1SignatureVerificationKey2018",
+                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                    "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
+                }, {
+                    "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-3",
+                    "type": "Secp256k1SignatureAuthentication2018",
+                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                    "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
+                }, {
+                    "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-3",
+                    "type": "Curve25519EncryptionPublicKey",
+                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                    "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
+                }],
+                "authentication": [{
+                    "type": "Secp256k1VerificationKey2018",
+                    "publicKey": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1"
+                }, {
+                    "type": "Secp256k1SignatureVerificationKey2018",
+                    "publicKey": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-2"
+                }],
+                "service": [],
+                "@context": "https://w3id.org/did/v1"
+            }
+            """
+        )
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "", JsonRPC("")))
+                .build()
+        )
+
+        coEvery { resolver.resolve(issuer) }.returns(doc)
+
+        val authenticators = JWTTools().resolveAuthenticator(alg, issuer, auth, resolver)
+
+        assertThat(authenticators).isEqualTo(listOf(doc.publicKey[0], doc.publicKey[1]))
+    }
+
+    @Deprecated("This test references the deprecated variant of JWTTools().resolveAuthenticator()" +
+            "This will be removed in the next major release.")
+    @Test
+    fun `errors if no suitable public keys exist for authentication (deprecated)`() = runBlocking {
+
+        val alg = "ES256K"
+        val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
+        val auth = true
+        val doc = EthrDIDDocument.fromJson(
+            """
+                    {
+                        "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                        "publicKey": [{
+                            "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                            "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
+                        }],
+                        "authentication": [],
+                        "service": [],
+                        "@context": "https://w3id.org/did/v1"
+                    }
+                    """
+        )
+
+        mockkObject(UniversalDID)
+
+        coEvery { UniversalDID.resolve(issuer) }.returns(doc)
+
+        coAssert {
+            JWTTools().resolveAuthenticator(alg, issuer, auth)
+        }.thrownError {
+            isInstanceOf(InvalidJWTException::class)
+        }
+    }
+
     @Test
     fun `errors if no suitable public keys exist for authentication`() = runBlocking {
 
@@ -515,6 +648,47 @@ class JWTToolsJVMTest {
                             "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
                             "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
                         }],
+                        "authentication": [],
+                        "service": [],
+                        "@context": "https://w3id.org/did/v1"
+                    }
+                    """
+        )
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(
+                    EthrDIDNetwork(
+                        "",
+                        "",
+                        JsonRPC("")
+                    )
+                )
+                .build()
+        )
+
+        coEvery { resolver.resolve(issuer) }.returns(doc)
+
+        coAssert {
+            JWTTools().resolveAuthenticator(alg, issuer, auth, resolver)
+        }.thrownError {
+            isInstanceOf(InvalidJWTException::class)
+        }
+    }
+
+    @Deprecated("This test references the deprecated variant of JWTTools().resolveAuthenticator()" +
+            "This will be removed in the next major release.")
+    @Test
+    fun `errors if no public keys exist (deprecated)`() = runBlocking {
+
+        val alg = "ES256K"
+        val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
+        val auth = false
+        val doc = EthrDIDDocument.fromJson(
+            """
+                    {
+                        "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                        "publicKey": [],
                         "authentication": [],
                         "service": [],
                         "@context": "https://w3id.org/did/v1"
@@ -551,19 +725,31 @@ class JWTToolsJVMTest {
                     """
         )
 
-        mockkObject(UniversalDID)
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(
+                    EthrDIDNetwork(
+                        "",
+                        "",
+                        JsonRPC("")
+                    )
+                )
+                .build()
+        )
 
-        coEvery { UniversalDID.resolve(issuer) }.returns(doc)
+        coEvery { resolver.resolve(issuer) }.returns(doc)
 
         coAssert {
-            JWTTools().resolveAuthenticator(alg, issuer, auth)
+            JWTTools().resolveAuthenticator(alg, issuer, auth, resolver)
         }.thrownError {
             isInstanceOf(InvalidJWTException::class)
         }
     }
 
+    @Deprecated("This test references the deprecated variant of JWTTools().verify()" +
+            "This will be removed in the next major release.")
     @Test
-    fun `errors if no supported signature types exist`() = runBlocking {
+    fun `errors if no supported signature types exist (deprecated)`() = runBlocking {
 
         val alg = "ESBAD"
         val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
@@ -586,6 +772,40 @@ class JWTToolsJVMTest {
 
         coAssert {
             JWTTools().resolveAuthenticator(alg, issuer, auth)
+        }.thrownError {
+            isInstanceOf(JWTEncodingException::class)
+        }
+    }
+
+
+    @Test
+    fun `errors if no supported signature types exist`() = runBlocking {
+
+        val alg = "ESBAD"
+        val issuer = "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4"
+        val auth = false
+        val doc = EthrDIDDocument.fromJson(
+            """
+                    {
+                        "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                        "publicKey": [],
+                        "authentication": [],
+                        "service": [],
+                        "@context": "https://w3id.org/did/v1"
+                    }
+                    """
+        )
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        coEvery { UniversalDID.resolve(issuer) }.returns(doc)
+
+        coAssert {
+            JWTTools().resolveAuthenticator(alg, issuer, auth, resolver)
         }.thrownError {
             isInstanceOf(JWTEncodingException::class)
         }

--- a/jwt/src/test/java/me/uport/sdk/jwt/TimestampTests.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/TimestampTests.kt
@@ -12,6 +12,7 @@ import me.uport.sdk.ethrdid.EthrDIDDocument
 import me.uport.sdk.ethrdid.EthrDIDNetwork
 import me.uport.sdk.ethrdid.EthrDIDResolver
 import me.uport.sdk.jsonrpc.JsonRPC
+import me.uport.sdk.jwt.test.EthrDIDTestHelpers
 import me.uport.sdk.jwt.test.EthrDIDTestHelpers.Companion.mockDocForAddress
 import me.uport.sdk.testhelpers.TestTimeProvider
 import me.uport.sdk.testhelpers.coAssert
@@ -86,27 +87,7 @@ class TimestampTests {
         )
 
         coEvery { resolver.resolve("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed") }.returns(
-            EthrDIDDocument.fromJson(
-                """{
-                            "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                            "publicKey": [{
-                                "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
-                                "type": "Secp256k1VerificationKey2018",
-                                "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                                "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                                "publicKeyHex": null,
-                                "publicKeyBase64": null,
-                                "publicKeyBase58": null,
-                                "value": null
-                            }],
-                            "authentication": [{
-                                "type": "Secp256k1SignatureAuthentication2018",
-                                "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
-                            }],
-                            "service": [],
-                            "@context": "https://w3id.org/did/v1"
-                        }"""
-            )
+            EthrDIDTestHelpers.mockDocForAddress("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
         )
 
         coAssert {
@@ -156,27 +137,7 @@ class TimestampTests {
         )
 
         coEvery { resolver.resolve("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed") }.returns(
-            EthrDIDDocument.fromJson(
-                """{
-                            "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                            "publicKey": [{
-                                "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
-                                "type": "Secp256k1VerificationKey2018",
-                                "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                                "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                                "publicKeyHex": null,
-                                "publicKeyBase64": null,
-                                "publicKeyBase58": null,
-                                "value": null
-                            }],
-                            "authentication": [{
-                                "type": "Secp256k1SignatureAuthentication2018",
-                                "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
-                            }],
-                            "service": [],
-                            "@context": "https://w3id.org/did/v1"
-                        }"""
-            )
+            EthrDIDTestHelpers.mockDocForAddress("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
         )
 
         coAssert {
@@ -318,27 +279,7 @@ class TimestampTests {
         )
 
         coEvery { resolver.resolve("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed") }.returns(
-            EthrDIDDocument.fromJson(
-                """{
-                            "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                            "publicKey": [{
-                                "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
-                                "type": "Secp256k1VerificationKey2018",
-                                "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                                "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                                "publicKeyHex": null,
-                                "publicKeyBase64": null,
-                                "publicKeyBase58": null,
-                                "value": null
-                            }],
-                            "authentication": [{
-                                "type": "Secp256k1SignatureAuthentication2018",
-                                "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
-                            }],
-                            "service": [],
-                            "@context": "https://w3id.org/did/v1"
-                        }"""
-            )
+            EthrDIDTestHelpers.mockDocForAddress("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
         )
 
         coAssert {
@@ -422,27 +363,7 @@ class TimestampTests {
         )
 
         coEvery { resolver.resolve("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed") }.returns(
-            EthrDIDDocument.fromJson(
-                """{
-                            "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                            "publicKey": [{
-                                "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
-                                "type": "Secp256k1VerificationKey2018",
-                                "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                                "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
-                                "publicKeyHex": null,
-                                "publicKeyBase64": null,
-                                "publicKeyBase58": null,
-                                "value": null
-                            }],
-                            "authentication": [{
-                                "type": "Secp256k1SignatureAuthentication2018",
-                                "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
-                            }],
-                            "service": [],
-                            "@context": "https://w3id.org/did/v1"
-                        }"""
-            )
+            EthrDIDTestHelpers.mockDocForAddress("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed")
         )
 
         val jwt =

--- a/jwt/src/test/java/me/uport/sdk/jwt/TimestampTests.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/TimestampTests.kt
@@ -8,6 +8,8 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.spyk
 import kotlinx.coroutines.runBlocking
+import me.uport.sdk.ethrdid.EthrDIDDocument
+import me.uport.sdk.ethrdid.EthrDIDNetwork
 import me.uport.sdk.ethrdid.EthrDIDResolver
 import me.uport.sdk.jsonrpc.JsonRPC
 import me.uport.sdk.jwt.test.EthrDIDTestHelpers.Companion.mockDocForAddress
@@ -42,8 +44,24 @@ class TimestampTests {
         UniversalDID.registerResolver(resolver)
     }
 
+    @Deprecated(
+        "This test references the deprecated variant of JWTTools().verify()" +
+                "This will be removed in the next major release."
+    )
+    @Test
+    fun `pass when nbf exists in the past (deprecated)`() = runBlocking {
+        val tested = JWTTools(TestTimeProvider(NOW))
 
+        val jwt =
+            """eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJuYmYiOjExMDAsImlzcyI6IjB4Y2YwM2RkMGE4OTRlZjc5Y2I1YjYwMWE0M2M0YjI1ZTNhZTRjNjdlZCJ9.w14TBtuK2k65tGYk1QmkehfQt3CBwTS0h23yKIliZZNB3wLgidyNpm8hIr04PLv4j-ayDlOLCZL73fGkd6YIJw"""
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded["nbf"]).isEqualTo(PAST)
+        assertThat(decoded.containsKey("iat")).isEqualTo(false)
 
+        coAssert {
+            tested.verify(jwt)
+        }.doesNotThrowAnyException()
+    }
 
     @Test
     fun `pass when nbf exists in the past`() = runBlocking {
@@ -54,6 +72,61 @@ class TimestampTests {
         val (_, decoded, _) = tested.decodeRaw(jwt)
         assertThat(decoded["nbf"]).isEqualTo(PAST)
         assertThat(decoded.containsKey("iat")).isEqualTo(false)
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(
+                    EthrDIDNetwork(
+                        "rinkeby",
+                        "0xregistry",
+                        JsonRPC("http://localhost:8545")
+                    )
+                )
+                .build()
+        )
+
+        coEvery { resolver.resolve("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed") }.returns(
+            EthrDIDDocument.fromJson(
+                """{
+                            "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                            "publicKey": [{
+                                "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
+                                "type": "Secp256k1VerificationKey2018",
+                                "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                                "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                                "publicKeyHex": null,
+                                "publicKeyBase64": null,
+                                "publicKeyBase58": null,
+                                "value": null
+                            }],
+                            "authentication": [{
+                                "type": "Secp256k1SignatureAuthentication2018",
+                                "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
+                            }],
+                            "service": [],
+                            "@context": "https://w3id.org/did/v1"
+                        }"""
+            )
+        )
+
+        coAssert {
+            tested.verify(jwt, resolver)
+        }.doesNotThrowAnyException()
+    }
+
+    @Deprecated(
+        "This test references the deprecated variant of JWTTools().verify()" +
+                "This will be removed in the next major release."
+    )
+    @Test
+    fun `pass when nbf exists in the past and iat in the future (deprecated)`() = runBlocking {
+        val tested = JWTTools(TestTimeProvider(NOW))
+
+        val jwt =
+            """eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJuYmYiOjExMDAsImlhdCI6MTkwMCwiaXNzIjoiMHhjZjAzZGQwYTg5NGVmNzljYjViNjAxYTQzYzRiMjVlM2FlNGM2N2VkIn0.qX5KAuGp7MZzpnH4AIeoy3qy9ndXD-A4F9SwsquYxDP4DKdfD32J1HqRmg55JDnRqAMwKy7OrhXL-RlaXqp7kA"""
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded["nbf"]).isEqualTo(PAST)
+        assertThat(decoded["iat"]).isEqualTo(FUTURE)
 
         coAssert {
             tested.verify(jwt)
@@ -70,9 +143,67 @@ class TimestampTests {
         assertThat(decoded["nbf"]).isEqualTo(PAST)
         assertThat(decoded["iat"]).isEqualTo(FUTURE)
 
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(
+                    EthrDIDNetwork(
+                        "rinkeby",
+                        "0xregistry",
+                        JsonRPC("http://localhost:8545")
+                    )
+                )
+                .build()
+        )
+
+        coEvery { resolver.resolve("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed") }.returns(
+            EthrDIDDocument.fromJson(
+                """{
+                            "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                            "publicKey": [{
+                                "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
+                                "type": "Secp256k1VerificationKey2018",
+                                "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                                "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                                "publicKeyHex": null,
+                                "publicKeyBase64": null,
+                                "publicKeyBase58": null,
+                                "value": null
+                            }],
+                            "authentication": [{
+                                "type": "Secp256k1SignatureAuthentication2018",
+                                "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
+                            }],
+                            "service": [],
+                            "@context": "https://w3id.org/did/v1"
+                        }"""
+            )
+        )
+
+        coAssert {
+            tested.verify(jwt, resolver)
+        }.doesNotThrowAnyException()
+    }
+
+    @Deprecated(
+        "This test references the deprecated variant of JWTTools().verify()" +
+                "This will be removed in the next major release."
+    )
+    @Test
+    fun `fail when nbf exists in the future (deprecated)`() = runBlocking {
+        val tested = JWTTools(TestTimeProvider(NOW))
+
+        val jwt =
+            """eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJuYmYiOjE5MDAsImlzcyI6IjB4Y2YwM2RkMGE4OTRlZjc5Y2I1YjYwMWE0M2M0YjI1ZTNhZTRjNjdlZCJ9.4Zk9GBiRuoTYT1PSCh5tlAYgjJmm9Oi-kA3--e2Jkw4MK3jUa09V-mDeIBHVxdmnKJ-F3XP2Rno3_gxcpuAciQ"""
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded["nbf"]).isEqualTo(FUTURE)
+        assertThat(decoded.containsKey("iat")).isEqualTo(false)
+
         coAssert {
             tested.verify(jwt)
-        }.doesNotThrowAnyException()
+        }.thrownError {
+            isInstanceOf(InvalidJWTException::class)
+            hasMessage("Jwt not valid before nbf: $FUTURE")
+        }
     }
 
     @Test
@@ -84,6 +215,34 @@ class TimestampTests {
         val (_, decoded, _) = tested.decodeRaw(jwt)
         assertThat(decoded["nbf"]).isEqualTo(FUTURE)
         assertThat(decoded.containsKey("iat")).isEqualTo(false)
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        coAssert {
+            tested.verify(jwt, resolver)
+        }.thrownError {
+            isInstanceOf(InvalidJWTException::class)
+            hasMessage("Jwt not valid before nbf: $FUTURE")
+        }
+    }
+
+    @Deprecated(
+        "This test references the deprecated variant of JWTTools().verify()" +
+                "This will be removed in the next major release."
+    )
+    @Test
+    fun `fail when nbf exists in the future and iat in the past (deprecated)`() = runBlocking {
+        val tested = JWTTools(TestTimeProvider(NOW))
+
+        val jwt =
+            """eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJuYmYiOjE5MDAsImlhdCI6MTEwMCwiaXNzIjoiMHhjZjAzZGQwYTg5NGVmNzljYjViNjAxYTQzYzRiMjVlM2FlNGM2N2VkIn0.jzpRnNfKQdamPMSg9Pcz8iz24H9qICMYdIquNb1kFPrE4S5RlX4jWAr5RKgakknmOanSzl2mM5znjjH8hfrj4Q"""
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded["nbf"]).isEqualTo(FUTURE)
+        assertThat(decoded["iat"]).isEqualTo(PAST)
 
         coAssert {
             tested.verify(jwt)
@@ -103,16 +262,26 @@ class TimestampTests {
         assertThat(decoded["nbf"]).isEqualTo(FUTURE)
         assertThat(decoded["iat"]).isEqualTo(PAST)
 
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
         coAssert {
-            tested.verify(jwt)
+            tested.verify(jwt, resolver)
         }.thrownError {
             isInstanceOf(InvalidJWTException::class)
             hasMessage("Jwt not valid before nbf: $FUTURE")
         }
     }
 
+    @Deprecated(
+        "This test references the deprecated variant of JWTTools().verify()" +
+                "This will be removed in the next major release."
+    )
     @Test
-    fun `pass when nbf missing and iat in the past`() = runBlocking {
+    fun `pass when nbf missing and iat in the past (deprecated)`() = runBlocking {
         val tested = JWTTools(TestTimeProvider(NOW))
         val jwt =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjExMDAsImlzcyI6IjB4Y2YwM2RkMGE4OTRlZjc5Y2I1YjYwMWE0M2M0YjI1ZTNhZTRjNjdlZCJ9.PpTCCQ3goDOvFTZ-owZul6IXfA5Wk2sypnWLgyn2LWrS2Eu2bWBVZ8FIt52AzKoaX1yW79S3WT5ZRjdf4NtCzA"
@@ -127,7 +296,62 @@ class TimestampTests {
     }
 
     @Test
-    fun `fail when nbf missing and iat in the future`() = runBlocking {
+    fun `pass when nbf missing and iat in the past`() = runBlocking {
+        val tested = JWTTools(TestTimeProvider(NOW))
+        val jwt =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjExMDAsImlzcyI6IjB4Y2YwM2RkMGE4OTRlZjc5Y2I1YjYwMWE0M2M0YjI1ZTNhZTRjNjdlZCJ9.PpTCCQ3goDOvFTZ-owZul6IXfA5Wk2sypnWLgyn2LWrS2Eu2bWBVZ8FIt52AzKoaX1yW79S3WT5ZRjdf4NtCzA"
+
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded.containsKey("nbf")).isEqualTo(false)
+        assertThat(decoded["iat"]).isEqualTo(PAST)
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(
+                    EthrDIDNetwork(
+                        "rinkeby",
+                        "0xregistry",
+                        JsonRPC("http://localhost:8545")
+                    )
+                )
+                .build()
+        )
+
+        coEvery { resolver.resolve("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed") }.returns(
+            EthrDIDDocument.fromJson(
+                """{
+                            "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                            "publicKey": [{
+                                "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
+                                "type": "Secp256k1VerificationKey2018",
+                                "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                                "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                                "publicKeyHex": null,
+                                "publicKeyBase64": null,
+                                "publicKeyBase58": null,
+                                "value": null
+                            }],
+                            "authentication": [{
+                                "type": "Secp256k1SignatureAuthentication2018",
+                                "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
+                            }],
+                            "service": [],
+                            "@context": "https://w3id.org/did/v1"
+                        }"""
+            )
+        )
+
+        coAssert {
+            tested.verify(jwt, resolver)
+        }.doesNotThrowAnyException()
+    }
+
+    @Deprecated(
+        "This test references the deprecated variant of JWTTools().verify()" +
+                "This will be removed in the next major release."
+    )
+    @Test
+    fun `fail when nbf missing and iat in the future (deprecated)`() = runBlocking {
         val tested = JWTTools(TestTimeProvider(NOW))
         val jwt =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE5MDAsImlzcyI6IjB4Y2YwM2RkMGE4OTRlZjc5Y2I1YjYwMWE0M2M0YjI1ZTNhZTRjNjdlZCJ9.PJ9wHrlcL_ScDretwS8q5izSmi4CZXRTyXyuhmlbVLGI0v2bioqMYLJZS6aMMEN1A6s7HT10BPFFt8XxLdZuvw"
@@ -145,7 +369,35 @@ class TimestampTests {
     }
 
     @Test
-    fun `pass when nbf and iat both missing`() = runBlocking {
+    fun `fail when nbf missing and iat in the future`() = runBlocking {
+        val tested = JWTTools(TestTimeProvider(NOW))
+        val jwt =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpYXQiOjE5MDAsImlzcyI6IjB4Y2YwM2RkMGE4OTRlZjc5Y2I1YjYwMWE0M2M0YjI1ZTNhZTRjNjdlZCJ9.PJ9wHrlcL_ScDretwS8q5izSmi4CZXRTyXyuhmlbVLGI0v2bioqMYLJZS6aMMEN1A6s7HT10BPFFt8XxLdZuvw"
+
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(EthrDIDNetwork("", "0xregistry", JsonRPC("")))
+                .build()
+        )
+
+        val (_, decoded, _) = tested.decodeRaw(jwt)
+        assertThat(decoded.containsKey("nbf")).isEqualTo(false)
+        assertThat(decoded["iat"]).isEqualTo(FUTURE)
+
+        coAssert {
+            tested.verify(jwt, resolver)
+        }.thrownError {
+            isInstanceOf(InvalidJWTException::class)
+            hasMessage("Jwt not valid yet (issued in the future) iat: $FUTURE")
+        }
+    }
+
+    @Deprecated(
+        "This test references the deprecated variant of JWTTools().verify()" +
+                "This will be removed in the next major release."
+    )
+    @Test
+    fun `pass when nbf and iat both missing (deprecated)`() = runBlocking {
         val jwt =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.0z278XpJdjQIgvaqSiJMoqBPBjp5Fy-QqjyT8Sgcbe0KGpCyd7001vLXr09X5aJ5kdcQYnnJ6QFYZeStQWId4w"
         val tested = JWTTools(TestTimeProvider(NOW))
@@ -154,5 +406,50 @@ class TimestampTests {
         }.doesNotThrowAnyException()
     }
 
+    @Test
+    fun `pass when nbf and iat both missing`() = runBlocking {
 
+        val resolver = spyk(
+            EthrDIDResolver.Builder()
+                .addNetwork(
+                    EthrDIDNetwork(
+                        "rinkeby",
+                        "0xregistry",
+                        JsonRPC("http://localhost:8545")
+                    )
+                )
+                .build()
+        )
+
+        coEvery { resolver.resolve("0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed") }.returns(
+            EthrDIDDocument.fromJson(
+                """{
+                            "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                            "publicKey": [{
+                                "id": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner",
+                                "type": "Secp256k1VerificationKey2018",
+                                "owner": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                                "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed",
+                                "publicKeyHex": null,
+                                "publicKeyBase64": null,
+                                "publicKeyBase58": null,
+                                "value": null
+                            }],
+                            "authentication": [{
+                                "type": "Secp256k1SignatureAuthentication2018",
+                                "publicKey": "did:ethr:0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed#owner"
+                            }],
+                            "service": [],
+                            "@context": "https://w3id.org/did/v1"
+                        }"""
+            )
+        )
+
+        val jwt =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NksifQ.eyJpc3MiOiIweGNmMDNkZDBhODk0ZWY3OWNiNWI2MDFhNDNjNGIyNWUzYWU0YzY3ZWQifQ.0z278XpJdjQIgvaqSiJMoqBPBjp5Fy-QqjyT8Sgcbe0KGpCyd7001vLXr09X5aJ5kdcQYnnJ6QFYZeStQWId4w"
+        val tested = JWTTools(TestTimeProvider(NOW))
+        coAssert {
+            tested.verify(jwt, resolver)
+        }.doesNotThrowAnyException()
+    }
 }


### PR DESCRIPTION
#### What's Here

This resolve the issue https://github.com/uport-project/kotlin-did-jwt/issues/30

1. Deprecated the previous `JWTTools().verify()` function which uses the `UniversalDID` to resolve DIDs in favor of a new approach

2. A new `JWTTools().verify()` function is created, which requires the developer to provide the `DIDResolver` to be used during verification

3. All previous tests for the verify method are duplicated.

4. Adding tests for `JWTTools().resolveAuthenticator()`

#### Tests
Run entire test suite with the command `./gradlew test cC --no-parallel`
