### PR TITLE
keys in did documents should list `controller` instead of `owner`

### DIFF
--- a/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
+++ b/ethr-did/src/main/java/me/uport/sdk/ethrdid/EthrDIDResolver.kt
@@ -203,7 +203,7 @@ open class EthrDIDResolver : DIDResolver {
                 "owner", PublicKeyEntry(
                     id = "$ownerDID#owner",
                     type = Secp256k1VerificationKey2018,
-                    owner = ownerDID,
+                    controller = ownerDID,
                     ethereumAddress = ownerAddress
                 )
             )
@@ -278,7 +278,7 @@ open class EthrDIDResolver : DIDResolver {
                 val pk = PublicKeyEntry(
                     id = "$normalizedDid#delegate-$delegateIndex",
                     type = type,
-                    owner = normalizedDid
+                    controller = normalizedDid
                 )
 
                 pkEntries[key] = when (encoding) {
@@ -335,7 +335,7 @@ open class EthrDIDResolver : DIDResolver {
                 veriKey.name -> pkEntries[key] = PublicKeyEntry(
                     id = "$ownerDID#delegate-$delegateIndex",
                     type = Secp256k1VerificationKey2018,
-                    owner = ownerDID,
+                    controller = ownerDID,
                     ethereumAddress = delegate
                 )
             }

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/DDOTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/DDOTest.kt
@@ -23,7 +23,7 @@ class DDOTest {
                 "publicKey": [{
                     "id": "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a#owner",
                     "type" : "Secp256k1VerificationKey2018",
-                    "owner" : "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
+                    "controller" : "did:ethr:0xb9c5714089478a327f09197987f16f9e5d936e8a",
                     "ethereumAddress" : "0xb9c5714089478a327f09197987f16f9e5d936e8a"
                 }],
                 "authentication": [{

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -831,7 +831,7 @@ class EthrDIDResolverTest {
                 "DIDAttributeChanged-did/pub/secp256k1/veriKey/hex-0x0295dda1dca7f80e308ef60155ddeac00e46b797fd40ef407f422e88d2467a27eb" to PublicKeyEntry(
                     id = "did:ethr:0xE6Fe788d8ca214A080b0f6aC7F48480b2AEfa9a6#delegate-1",
                     type = PublicKeyType("secp256k1VerificationKey2018"),
-                    owner = "did:ethr:0xE6Fe788d8ca214A080b0f6aC7F48480b2AEfa9a6",
+                    controller = "did:ethr:0xE6Fe788d8ca214A080b0f6aC7F48480b2AEfa9a6",
                     publicKeyHex = "0x0295dda1dca7f80e308ef60155ddeac00e46b797fd40ef407f422e88d2467a27eb"
                 )
             ) to emptyMap<String, ServiceEntry>()

--- a/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
+++ b/ethr-did/src/test/java/me/uport/sdk/ethrdid/EthrDIDResolverTest.kt
@@ -259,13 +259,13 @@ class EthrDIDResolverTest {
                 {
                   "id": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656#owner",
                   "type": "Secp256k1VerificationKey2018",
-                  "owner": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656",
+                  "controller": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656",
                   "ethereumAddress": "0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656"
                 },
                 {
                   "id": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656#delegate-1",
                   "type": "Secp256k1VerificationKey2018",
-                  "owner": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656",
+                  "controller": "did:ethr:0x62d283fe6939c01fc88f02c6d2c9a547cc3e2656",
                   "ethereumAddress": "0xcf03dd0a894ef79cb5b601a43c4b25e3ae4c67ed"
                 }
               ],

--- a/jwt-test/src/main/java/me/uport/sdk/jwt/test/EthrDIDTestHelpers.kt
+++ b/jwt-test/src/main/java/me/uport/sdk/jwt/test/EthrDIDTestHelpers.kt
@@ -26,7 +26,7 @@ open class EthrDIDTestHelpers {
                     PublicKeyEntry(
                         id = "$did#owner",
                         type = PublicKeyType.Secp256k1VerificationKey2018,
-                        owner = did,
+                        controller = did,
                         ethereumAddress = address
                     )
                 ),

--- a/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
+++ b/jwt/src/test/java/me/uport/sdk/jwt/JWTToolsJVMTest.kt
@@ -35,14 +35,10 @@ class JWTToolsJVMTest {
         mockkObject(UniversalDID)
 
         coEvery { UniversalDID.resolve("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154") }.returns(
-            EthrDIDDocument.fromJson(
-                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
-            )
+            EthrDIDTestHelpers.mockDocForAddress("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154")
         )
         coEvery { UniversalDID.resolve("did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4") }.returns(
-            EthrDIDDocument.fromJson(
-                """{"id":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4","publicKey":[{"id":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4","ethereumAddress":"0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
-            )
+            EthrDIDTestHelpers.mockDocForAddress("did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4")
         )
 
         tokens.forEach { token ->
@@ -64,14 +60,10 @@ class JWTToolsJVMTest {
         )
 
         coEvery { resolver.resolve("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154") }.returns(
-            EthrDIDDocument.fromJson(
-                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
-            )
+            EthrDIDTestHelpers.mockDocForAddress("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154")
         )
         coEvery { resolver.resolve("did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4") }.returns(
-            EthrDIDDocument.fromJson(
-                """{"id":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4","publicKey":[{"id":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4","ethereumAddress":"0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
-            )
+            EthrDIDTestHelpers.mockDocForAddress("did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4")
         )
 
         tokens.forEach { token ->
@@ -146,8 +138,8 @@ class JWTToolsJVMTest {
     fun `returns correct payload after successful verification (deprecated)`() = runBlocking {
         mockkObject(UniversalDID)
 
-        coEvery { UniversalDID.resolve("2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG") }.returns(UportDIDDocument.fromJson("""{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKey":[{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1","type":"Secp256k1VerificationKey2018","owner":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKeyHex":"04171fcc7654cad14745b9835bc534d8e59038ae6929c793d7f8dd2c934580ca39ff1e2de3d7ef69a8daba5e5590d3ec80486a273cbe2bd1b76ebd01f949b41463"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/Qmez4bdFmxPknbAoGzHmpjpLjQFChq39h5UMPGiwUHgt8f"},"name":"uPort Demo","description":"Demo App"}}"""))
-        coEvery { UniversalDID.resolve("2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf") }.returns(UportDIDDocument.fromJson("""{"id":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf","publicKey":[{"id":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf#keys-1","type":"Secp256k1VerificationKey2018","owner":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf","publicKeyHex":"0422d2edad30d8588c0661e032f37af8177cfa0a056ee9b8ca953b07c6600a637c002ed22fe6612e28e558aee130d399ba97f89e25c16661a99c8af8c832b88568"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/QmdznPoNSnc6RawSzzvNFX5HerF62Vu7sbP3vSur9gDFGb"},"name":"Olorun","description":"Private network configuration service"}}"""))
+        coEvery { UniversalDID.resolve("2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG") }.returns(UportDIDDocument.fromJson("""{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKey":[{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1","type":"Secp256k1VerificationKey2018","controller":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKeyHex":"04171fcc7654cad14745b9835bc534d8e59038ae6929c793d7f8dd2c934580ca39ff1e2de3d7ef69a8daba5e5590d3ec80486a273cbe2bd1b76ebd01f949b41463"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/Qmez4bdFmxPknbAoGzHmpjpLjQFChq39h5UMPGiwUHgt8f"},"name":"uPort Demo","description":"Demo App"}}"""))
+        coEvery { UniversalDID.resolve("2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf") }.returns(UportDIDDocument.fromJson("""{"id":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf","publicKey":[{"id":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf#keys-1","type":"Secp256k1VerificationKey2018","controller":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf","publicKeyHex":"0422d2edad30d8588c0661e032f37af8177cfa0a056ee9b8ca953b07c6600a637c002ed22fe6612e28e558aee130d399ba97f89e25c16661a99c8af8c832b88568"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/QmdznPoNSnc6RawSzzvNFX5HerF62Vu7sbP3vSur9gDFGb"},"name":"Olorun","description":"Private network configuration service"}}"""))
 
         val shareReqPayload = JWTTools(TestTimeProvider(1520366666000L)).verify(validShareReqToken1)
         assertThat(shareReqPayload).isEqualTo(expectedShareReqPayload1)
@@ -164,13 +156,13 @@ class JWTToolsJVMTest {
         coEvery {
             resolver.resolve("2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG")
         }.returns(
-            UportDIDDocument.fromJson("""{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKey":[{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1","type":"Secp256k1VerificationKey2018","owner":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKeyHex":"04171fcc7654cad14745b9835bc534d8e59038ae6929c793d7f8dd2c934580ca39ff1e2de3d7ef69a8daba5e5590d3ec80486a273cbe2bd1b76ebd01f949b41463"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/Qmez4bdFmxPknbAoGzHmpjpLjQFChq39h5UMPGiwUHgt8f"},"name":"uPort Demo","description":"Demo App"}}""")
+            UportDIDDocument.fromJson("""{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKey":[{"id":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1","type":"Secp256k1VerificationKey2018","controller":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG","publicKeyHex":"04171fcc7654cad14745b9835bc534d8e59038ae6929c793d7f8dd2c934580ca39ff1e2de3d7ef69a8daba5e5590d3ec80486a273cbe2bd1b76ebd01f949b41463"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2oeXufHGDpU51bfKBsZDdu7Je9weJ3r7sVG#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/Qmez4bdFmxPknbAoGzHmpjpLjQFChq39h5UMPGiwUHgt8f"},"name":"uPort Demo","description":"Demo App"}}""")
         )
 
         coEvery {
             resolver.resolve("2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf")
         }.returns(
-            UportDIDDocument.fromJson("""{"id":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf","publicKey":[{"id":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf#keys-1","type":"Secp256k1VerificationKey2018","owner":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf","publicKeyHex":"0422d2edad30d8588c0661e032f37af8177cfa0a056ee9b8ca953b07c6600a637c002ed22fe6612e28e558aee130d399ba97f89e25c16661a99c8af8c832b88568"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/QmdznPoNSnc6RawSzzvNFX5HerF62Vu7sbP3vSur9gDFGb"},"name":"Olorun","description":"Private network configuration service"}}""")
+            UportDIDDocument.fromJson("""{"id":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf","publicKey":[{"id":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf#keys-1","type":"Secp256k1VerificationKey2018","controller":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf","publicKeyHex":"0422d2edad30d8588c0661e032f37af8177cfa0a056ee9b8ca953b07c6600a637c002ed22fe6612e28e558aee130d399ba97f89e25c16661a99c8af8c832b88568"}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:uport:2omRJZL23ZCYgc1rZrFVpFXJpWoaEEuJUcf#keys-1"}],"service":[],"@context":"https://w3id.org/did/v1","uportProfile":{"@type":"App","image":{"@type":"ImageObject","name":"avatar","contentUrl":"/ipfs/QmdznPoNSnc6RawSzzvNFX5HerF62Vu7sbP3vSur9gDFGb"},"name":"Olorun","description":"Private network configuration service"}}""")
         )
 
         val shareReqPayload = JWTTools(TestTimeProvider(1520366666000L)).verify(validShareReqToken1, resolver)
@@ -205,9 +197,7 @@ class JWTToolsJVMTest {
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1MzUwMTY3MDIsImV4cCI6MTUzNTEwMzEwMiwiYXVkIjoiZGlkOmV0aHI6MHhhOWUzMjMyYjYxYmRiNjcyNzEyYjlhZTMzMTk1MDY5ZDhkNjUxYzFhIiwidHlwZSI6InNoYXJlUmVzcCIsIm5hZCI6IjJvZHpqVGFpOFJvNFYzS3hrbTNTblppdjlXU1l1Tm9aNEFoIiwib3duIjp7Im5hbWUiOiJ1UG9ydCBVc2VyIn0sInJlcSI6ImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSkZVekkxTmtzdFVpSjkuZXlKcFlYUWlPakUxTXpVd01UWTJPREVzSW1WNGNDSTZNVFV6TlRBeE56STRNU3dpY21WeGRXVnpkR1ZrSWpwYkltNWhiV1VpTENKd2FHOXVaU0lzSW1OdmRXNTBjbmtpWFN3aWNHVnliV2x6YzJsdmJuTWlPbHNpYm05MGFXWnBZMkYwYVc5dWN5SmRMQ0pqWVd4c1ltRmpheUk2SW1oMGRIQnpPaTh2WTJoaGMzRjFhUzUxY0c5eWRDNXRaUzloY0drdmRqRXZkRzl3YVdNdmJVVXpTbVpXZWxOMFNuUnFhbnBvWWpSYVRFRnhkeUlzSW1GamRDSTZJbXRsZVhCaGFYSWlMQ0owZVhCbElqb2ljMmhoY21WU1pYRWlMQ0pwYzNNaU9pSmthV1E2WlhSb2Nqb3dlR0U1WlRNeU16SmlOakZpWkdJMk56STNNVEppT1dGbE16TXhPVFV3Tmpsa09HUTJOVEZqTVdFaWZRLnVScUdGd01XNnpWSDR4OWFmTDAtS29qSEYwVF9GbW9QWnR6OG5uSjRFXzhNY2cxejBBZ21aMnplOE5iS05wVUNnRHRwTU9RNzVGSjU4WmhzbWFxQUxBRSIsImNhcGFiaWxpdGllcyI6WyJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpGVXpJMU5rc3RVaUo5LmV5SnBZWFFpT2pFMU16VXdNVFkzTURFc0ltVjRjQ0k2TVRVek5qTXhNamN3TVN3aVlYVmtJam9pWkdsa09tVjBhSEk2TUhoaE9XVXpNak15WWpZeFltUmlOamN5TnpFeVlqbGhaVE16TVRrMU1EWTVaRGhrTmpVeFl6RmhJaXdpZEhsd1pTSTZJbTV2ZEdsbWFXTmhkR2x2Ym5NaUxDSjJZV3gxWlNJNkltRnlianBoZDNNNmMyNXpPblZ6TFhkbGMzUXRNam94TVRNeE9UWXlNVFkxTlRnNlpXNWtjRzlwYm5RdlIwTk5MM1ZRYjNKMEx6UXpNRGsxTWpZMkxUSmhPR1F0TTJFMFpTMWlaRFV3TFRka01USm1ZVE00TWpRNFlpSXNJbWx6Y3lJNkltUnBaRHBsZEdoeU9qQjRNVEE0TWpBNVpqUXlORGRpTjJabE5qWXdOV0l3WmpVNFpqa3hORFZsWXpNeU5qbGtNREUxTkNKOS5Lc0F6TmVDeHFDaF9rMkt4aTYtWHFveFNXZjBCLWFFR0xXdi1ldHVXQlF2QU5neDFTMG5oZ0ppRkllUnRXakw4ekdnVVV3MUlsSWJtYUZrOEo5aGdhd0UiXSwiYm94UHViIjoiY2g3aGI2S3hsakJ2bXh5UDJXZENWTFNTLzQ2S1hCcmdkWG1Mcm03VEpIST0iLCJpc3MiOiJkaWQ6ZXRocjoweDEwODIwOWY0MjQ3YjdmZTY2MDViMGY1OGY5MTQ1ZWMzMjY5ZDAxNTQifQ.Ncf8B_y0Ha8gdaYyCaL5jLX2RsKTMwxTQ8KlybXFygsxKUUQm9OXo4lU65fduIaFvVyPOP6Oe2adar8m0m2aiwA"
 
         coEvery { UniversalDID.resolve("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154") }.returns(
-            EthrDIDDocument.fromJson(
-                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
-            )
+            EthrDIDTestHelpers.mockDocForAddress("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154")
         )
 
         coAssert {
@@ -232,9 +222,7 @@ class JWTToolsJVMTest {
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1MzUwMTY3MDIsImV4cCI6MTUzNTEwMzEwMiwiYXVkIjoiZGlkOmV0aHI6MHhhOWUzMjMyYjYxYmRiNjcyNzEyYjlhZTMzMTk1MDY5ZDhkNjUxYzFhIiwidHlwZSI6InNoYXJlUmVzcCIsIm5hZCI6IjJvZHpqVGFpOFJvNFYzS3hrbTNTblppdjlXU1l1Tm9aNEFoIiwib3duIjp7Im5hbWUiOiJ1UG9ydCBVc2VyIn0sInJlcSI6ImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSkZVekkxTmtzdFVpSjkuZXlKcFlYUWlPakUxTXpVd01UWTJPREVzSW1WNGNDSTZNVFV6TlRBeE56STRNU3dpY21WeGRXVnpkR1ZrSWpwYkltNWhiV1VpTENKd2FHOXVaU0lzSW1OdmRXNTBjbmtpWFN3aWNHVnliV2x6YzJsdmJuTWlPbHNpYm05MGFXWnBZMkYwYVc5dWN5SmRMQ0pqWVd4c1ltRmpheUk2SW1oMGRIQnpPaTh2WTJoaGMzRjFhUzUxY0c5eWRDNXRaUzloY0drdmRqRXZkRzl3YVdNdmJVVXpTbVpXZWxOMFNuUnFhbnBvWWpSYVRFRnhkeUlzSW1GamRDSTZJbXRsZVhCaGFYSWlMQ0owZVhCbElqb2ljMmhoY21WU1pYRWlMQ0pwYzNNaU9pSmthV1E2WlhSb2Nqb3dlR0U1WlRNeU16SmlOakZpWkdJMk56STNNVEppT1dGbE16TXhPVFV3Tmpsa09HUTJOVEZqTVdFaWZRLnVScUdGd01XNnpWSDR4OWFmTDAtS29qSEYwVF9GbW9QWnR6OG5uSjRFXzhNY2cxejBBZ21aMnplOE5iS05wVUNnRHRwTU9RNzVGSjU4WmhzbWFxQUxBRSIsImNhcGFiaWxpdGllcyI6WyJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpGVXpJMU5rc3RVaUo5LmV5SnBZWFFpT2pFMU16VXdNVFkzTURFc0ltVjRjQ0k2TVRVek5qTXhNamN3TVN3aVlYVmtJam9pWkdsa09tVjBhSEk2TUhoaE9XVXpNak15WWpZeFltUmlOamN5TnpFeVlqbGhaVE16TVRrMU1EWTVaRGhrTmpVeFl6RmhJaXdpZEhsd1pTSTZJbTV2ZEdsbWFXTmhkR2x2Ym5NaUxDSjJZV3gxWlNJNkltRnlianBoZDNNNmMyNXpPblZ6TFhkbGMzUXRNam94TVRNeE9UWXlNVFkxTlRnNlpXNWtjRzlwYm5RdlIwTk5MM1ZRYjNKMEx6UXpNRGsxTWpZMkxUSmhPR1F0TTJFMFpTMWlaRFV3TFRka01USm1ZVE00TWpRNFlpSXNJbWx6Y3lJNkltUnBaRHBsZEdoeU9qQjRNVEE0TWpBNVpqUXlORGRpTjJabE5qWXdOV0l3WmpVNFpqa3hORFZsWXpNeU5qbGtNREUxTkNKOS5Lc0F6TmVDeHFDaF9rMkt4aTYtWHFveFNXZjBCLWFFR0xXdi1ldHVXQlF2QU5neDFTMG5oZ0ppRkllUnRXakw4ekdnVVV3MUlsSWJtYUZrOEo5aGdhd0UiXSwiYm94UHViIjoiY2g3aGI2S3hsakJ2bXh5UDJXZENWTFNTLzQ2S1hCcmdkWG1Mcm03VEpIST0iLCJpc3MiOiJkaWQ6ZXRocjoweDEwODIwOWY0MjQ3YjdmZTY2MDViMGY1OGY5MTQ1ZWMzMjY5ZDAxNTQifQ.Ncf8B_y0Ha8gdaYyCaL5jLX2RsKTMwxTQ8KlybXFygsxKUUQm9OXo4lU65fduIaFvVyPOP6Oe2adar8m0m2aiwA"
 
         coEvery { resolver.resolve("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154") }.returns(
-            EthrDIDDocument.fromJson(
-                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
-            )
+            EthrDIDTestHelpers.mockDocForAddress("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154")
         )
 
         coAssert {
@@ -258,7 +246,7 @@ class JWTToolsJVMTest {
 
         coEvery { UniversalDID.resolve("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154") }.returns(
             EthrDIDDocument.fromJson(
-                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
+                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","controller":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
             )
         )
 
@@ -286,7 +274,7 @@ class JWTToolsJVMTest {
 
         coEvery { resolver.resolve("did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154") }.returns(
             EthrDIDDocument.fromJson(
-                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
+                """{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKey":[{"id":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner","type":"Secp256k1VerificationKey2018","controller":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154","ethereumAddress":"0x108209f4247b7fe6605b0f58f9145ec3269d0154","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
             )
         )
 
@@ -373,7 +361,7 @@ class JWTToolsJVMTest {
         mockkObject(UniversalDID)
         coEvery { UniversalDID.resolve("did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9") }.returns(
             EthrDIDDocument.fromJson(
-                """{"id":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9","publicKey":[{"id":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9","ethereumAddress":"0x6985a110df37555235d7d0de0a0fb28c9848dfa9","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
+                """{"id":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9","publicKey":[{"id":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9#owner","type":"Secp256k1VerificationKey2018","controller":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9","ethereumAddress":"0x6985a110df37555235d7d0de0a0fb28c9848dfa9","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
             )
         )
 
@@ -399,7 +387,7 @@ class JWTToolsJVMTest {
 
         coEvery { resolver.resolve("did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9") }.returns(
             EthrDIDDocument.fromJson(
-                """{"id":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9","publicKey":[{"id":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9#owner","type":"Secp256k1VerificationKey2018","owner":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9","ethereumAddress":"0x6985a110df37555235d7d0de0a0fb28c9848dfa9","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
+                """{"id":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9","publicKey":[{"id":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9#owner","type":"Secp256k1VerificationKey2018","controller":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9","ethereumAddress":"0x6985a110df37555235d7d0de0a0fb28c9848dfa9","publicKeyHex":null,"publicKeyBase64":null,"publicKeyBase58":null,"value":null}],"authentication":[{"type":"Secp256k1SignatureAuthentication2018","publicKey":"did:ethr:0x6985a110df37555235d7d0de0a0fb28c9848dfa9#owner"}],"service":[],"@context":"https://w3id.org/did/v1"}"""
             )
         )
 
@@ -428,7 +416,7 @@ class JWTToolsJVMTest {
                         "publicKey": [{
                             "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1",
                             "type": "Secp256k1VerificationKey2018",
-                            "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                            "controller": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
                             "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
                         }],
                         "authentication": [],
@@ -464,22 +452,22 @@ class JWTToolsJVMTest {
                 "publicKey": [{
                     "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1",
                     "type": "Secp256k1VerificationKey2018",
-                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                    "controller": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
                     "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
                 }, {
                     "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-2",
                     "type": "Secp256k1SignatureVerificationKey2018",
-                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                    "controller": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
                     "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
                 }, {
                     "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-3",
                     "type": "Secp256k1SignatureAuthentication2018",
-                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                    "controller": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
                     "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
                 }, {
                     "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-3",
                     "type": "Curve25519EncryptionPublicKey",
-                    "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                    "controller": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
                     "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
                 }],
                 "authentication": [{
@@ -522,7 +510,7 @@ class JWTToolsJVMTest {
                         "publicKey": [{
                             "id": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4#keys-1",
                             "type": "Secp256k1VerificationKey2018",
-                            "owner": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
+                            "controller": "did:ethr:0xe8c91bde7625ab2c0ed9f214deb39440da7e03c4",
                             "publicKeyHex": "04613bb3a4874d27032618f020614c21cbe4c4e4781687525f6674089f9bd3d6c7f6eb13569053d31715a3ba32e0b791b97922af6387f087d6b5548c06944ab061"
                         }],
                         "authentication": [],

--- a/universal-did/src/main/java/me/uport/sdk/universaldid/DIDDocument.kt
+++ b/universal-did/src/main/java/me/uport/sdk/universaldid/DIDDocument.kt
@@ -71,7 +71,7 @@ data class PublicKeyEntry(
     val type: PublicKeyType,
 
     @SerialName("controller")
-    val owner: String,
+    val controller: String,
 
     @SerialName("ethereumAddress")
     val ethereumAddress: String? = null,

--- a/universal-did/src/main/java/me/uport/sdk/universaldid/DIDDocument.kt
+++ b/universal-did/src/main/java/me/uport/sdk/universaldid/DIDDocument.kt
@@ -70,7 +70,7 @@ data class PublicKeyEntry(
     @SerialName("type")
     val type: PublicKeyType,
 
-    @SerialName("owner")
+    @SerialName("controller")
     val owner: String,
 
     @SerialName("ethereumAddress")

--- a/uport-did/src/main/java/me/uport/sdk/uportdid/UportIdentityDocument.kt
+++ b/uport-did/src/main/java/me/uport/sdk/uportdid/UportIdentityDocument.kt
@@ -52,7 +52,7 @@ data class UportIdentityDocument(
         val publicVerificationKey = PublicKeyEntry(
             id = "$normalizedDid#keys-1",
             type = Secp256k1VerificationKey2018,
-            owner = normalizedDid,
+            controller = normalizedDid,
             publicKeyHex = this.publicKey?.clean0xPrefix()
         )
         val authEntries = listOf(
@@ -69,7 +69,7 @@ data class UportIdentityDocument(
                 PublicKeyEntry(
                     id = "$normalizedDid#keys-2",
                     type = Curve25519EncryptionPublicKey,
-                    owner = normalizedDid,
+                    controller = normalizedDid,
                     publicKeyBase64 = publicEncKey
                 )
             )

--- a/uport-did/src/test/java/me/uport/sdk/uportdid/UportDIDResolverTest.kt
+++ b/uport-did/src/test/java/me/uport/sdk/uportdid/UportDIDResolverTest.kt
@@ -76,7 +76,7 @@ class UportDIDResolverTest {
 
         val verificationPkMatch = convertedDDO.publicKey.find { it ->
             it.id.startsWith(expectedOwner) &&
-                    it.owner == expectedOwner &&
+                    it.controller == expectedOwner &&
                     it.type == Secp256k1VerificationKey2018 &&
                     it.publicKeyHex == publicKeyHex.clean0xPrefix()
         }
@@ -84,7 +84,7 @@ class UportDIDResolverTest {
 
         val encPkMatch = convertedDDO.publicKey.find { it ->
             it.id.startsWith(expectedOwner) &&
-                    it.owner == expectedOwner &&
+                    it.controller == expectedOwner &&
                     it.type == Curve25519EncryptionPublicKey &&
                     it.publicKeyBase64 == publicEncKey
         }

--- a/web-did/src/test/java/me/uport/sdk/httpsdid/WebDIDResolverTest.kt
+++ b/web-did/src/test/java/me/uport/sdk/httpsdid/WebDIDResolverTest.kt
@@ -45,7 +45,7 @@ class WebDIDResolverTest {
             PublicKeyEntry(
                 id = "did:web:uport.me#owner",
                 type = PublicKeyType.Secp256k1VerificationKey2018,
-                owner = "did:web:uport.me",
+                controller = "did:web:uport.me",
                 publicKeyHex = "042b0af9b3ae6c7c3a90b01a3879d9518081bc0dcdf038488db9cb109b082a77d97ea3373e3dfde0eccd9adbdce11d0302ea5c098dbb0b310234c86895c8641622"
             )
         ),

--- a/web-did/src/test/java/me/uport/sdk/httpsdid/WebDIDResolverTest.kt
+++ b/web-did/src/test/java/me/uport/sdk/httpsdid/WebDIDResolverTest.kt
@@ -25,7 +25,7 @@ class WebDIDResolverTest {
     {
       "id": "did:web:uport.me#owner",
       "type": "Secp256k1VerificationKey2018",
-      "owner": "did:web:uport.me",
+      "controller": "did:web:uport.me",
       "publicKeyHex": "042b0af9b3ae6c7c3a90b01a3879d9518081bc0dcdf038488db9cb109b082a77d97ea3373e3dfde0eccd9adbdce11d0302ea5c098dbb0b310234c86895c8641622"
     }
   ],


### PR DESCRIPTION
#### What's Here
This resolves the issue https://github.com/uport-project/kotlin-did-jwt/issues/29

- Updated the `owner` key in `DIDDocument` to `controller` as stated in the DID spec 
- Updated existing tests

#### Testing
Rund the entire test suite using the command `./gradlew test cC --no-parallel`
