### PR TITLE
Revocations support for ALL did types

### DIFF
--- a/credential-status/src/main/java/me/uport/credential_status/StatusResolver.kt
+++ b/credential-status/src/main/java/me/uport/credential_status/StatusResolver.kt
@@ -1,5 +1,7 @@
 package me.uport.credential_status
 
+import me.uport.sdk.universaldid.DIDDocument
+
 /**
  * Generic interface representing a credential-status result
  **/
@@ -38,5 +40,5 @@ interface StatusResolver {
      *
      * Checks the status of a given credential and returns a [CredentialStatus] or throws an error
      */
-    suspend fun checkStatus(credential: String): CredentialStatus
+    suspend fun checkStatus(credential: String, didDoc: DIDDocument): CredentialStatus
 }

--- a/credential-status/src/main/java/me/uport/credential_status/UniversalStatusResolver.kt
+++ b/credential-status/src/main/java/me/uport/credential_status/UniversalStatusResolver.kt
@@ -1,5 +1,6 @@
 package me.uport.credential_status
 
+import me.uport.sdk.universaldid.DIDDocument
 import me.uport.sdk.universaldid.UniversalDID.method
 import me.uport.sdk.universaldid.UniversalDID.registerResolver
 
@@ -31,14 +32,14 @@ class UniversalStatusResolver : StatusResolver {
      *
      * @throws IllegalStateException if the proper resolver is not registered or produces `null`
      */
-    override suspend fun checkStatus(credential: String): CredentialStatus {
+    override suspend fun checkStatus(credential: String, didDoc: DIDDocument): CredentialStatus {
 
         val statusEntry = getStatusEntry(credential)
 
         if (statusEntry.type.isBlank() || !resolvers.containsKey(statusEntry.type)) {
             throw IllegalStateException("There is no StatusResolver registered to check status using '${statusEntry.type}' method.")
         } else {
-            return resolvers[statusEntry.type]?.checkStatus(credential)
+            return resolvers[statusEntry.type]?.checkStatus(credential, didDoc)
                 ?: throw IllegalStateException("There StatusResolver for '$statusEntry.type' failed to resolve for an unknown reason.")
         }
     }

--- a/credential-status/src/test/java/me/uport/sdk/credential_status/UniversalStatusResolverTests.kt
+++ b/credential-status/src/test/java/me/uport/sdk/credential_status/UniversalStatusResolverTests.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.runBlocking
 import me.uport.credential_status.CredentialStatus
 import me.uport.credential_status.StatusResolver
 import me.uport.credential_status.UniversalStatusResolver
+import me.uport.sdk.ethrdid.EthrDIDDocument
 import me.uport.sdk.testhelpers.coAssert
+import me.uport.sdk.universaldid.DIDDocument
 import org.junit.Test
 import java.math.BigInteger
 
@@ -17,11 +19,27 @@ class UniversalStatusResolverTests {
     private val successfulCred =
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJzdGF0dXMiOnsidHlwZSI6InRlc3QiLCJpZCI6InRlc3Q6MHgxMjM0NSJ9fQ.MFTcBa_41fN5NoNYxTNYi9WmssHIOHz7Y8CPTDTpG-E"
 
+    private val didDoc = EthrDIDDocument.fromJson(
+        """{
+                "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                "publicKey": [],
+                "authentication": [{
+                    "type": "Secp256k1SignatureAuthentication2018",
+                    "publicKey": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
+                }],
+                "service": [],
+                "@context": "https://w3id.org/did/v1"
+            }"""
+    )
+
     private val testResolver = object : StatusResolver {
 
         override val method: String = "test"
 
-        override suspend fun checkStatus(credential: String): CredentialStatus {
+        override suspend fun checkStatus(
+            credential: String,
+            didDoc: DIDDocument
+        ): CredentialStatus {
             if (credential == successfulCred) {
                 return TestStatus(BigInteger.ONE)
             } else {
@@ -39,6 +57,7 @@ class UniversalStatusResolverTests {
         coAssert {
             UniversalStatusResolver().checkStatus(
                 "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzMwNDczNTEsInN0YXR1cyI6eyJ0eXBlIjoiRXRoclN0YXR1c1JlZ2lzdHJ5MjAxOSIsImlkIjoicmlua2VieToweDFFNDY1MWRjYTVFZjM4NjM2ZTJFNEQ3QTZGZjRkMjQxM2ZDNTY0NTAifSwiaXNzIjoiZGlkOmV0aHI6MHgxZmNmOGZmNzhhYzUxMTdkOWM5OWI4MzBjNzRiNjY2OGQ2YWMzMjI5In0.MHabafA0UxJuQJ0Z-7Egb57WRlgj4_zf96B0LUhRyXgVDU5RABIczTTTXWjcuKVzhJc_-FuhRI8uQYmQQNxKzgA"
+                , didDoc
             )
         }.thrownError {
             isInstanceOf(IllegalStateException::class)
@@ -50,7 +69,10 @@ class UniversalStatusResolverTests {
         val resolver = UniversalStatusResolver()
         resolver.registerResolver(testResolver)
         coAssert {
-            resolver.checkStatus("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+            resolver.checkStatus(
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+                didDoc
+            )
         }.thrownError {
             isInstanceOf(IllegalArgumentException::class)
         }
@@ -60,7 +82,7 @@ class UniversalStatusResolverTests {
     fun `can register resolvers and use to check status`() = runBlocking {
         val resolver = UniversalStatusResolver()
         resolver.registerResolver(testResolver)
-        val result = resolver.checkStatus(successfulCred)
+        val result = resolver.checkStatus(successfulCred, didDoc)
         assertThat(result).isEqualTo(TestStatus(BigInteger.ONE))
     }
 }

--- a/ethr-did/build.gradle
+++ b/ethr-did/build.gradle
@@ -32,4 +32,5 @@ dependencies {
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
     testImplementation project(":jwt-test")
     testImplementation "com.github.uport-project.kotlin-common:test-helpers:$uport_kotlin_common_version"
+    testImplementation "com.squareup.okhttp3:okhttp:$okhttp_version"
 }

--- a/ethr-status/build.gradle
+++ b/ethr-status/build.gradle
@@ -21,4 +21,5 @@ dependencies {
 
     testImplementation "junit:junit:$junit_version"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
+    testImplementation "com.squareup.okhttp3:okhttp:$okhttp_version"
 }

--- a/ethr-status/src/main/java/me/uport/sdk/ethr_status/EthrStatusResolver.kt
+++ b/ethr-status/src/main/java/me/uport/sdk/ethr_status/EthrStatusResolver.kt
@@ -77,17 +77,24 @@ class EthrStatusResolver : StatusResolver {
         return EthrStatus(BigInteger.ZERO)
     }
 
+    /*
+     * Generates a list of valid revoker addresses using the
+     * list of public key entries in the [DIDDocument]
+     * @returns a list of ethereum addresses for valid revokers
+     *
+     */
     internal fun getValidRevokers(didDoc: DIDDocument): List<String> {
 
-        val revokers = didDoc.publicKey.filter { pubKey ->
-            pubKey.ethereumAddress != null
-        }.map { pubKey ->
-            pubKey.ethereumAddress as String
+        val revokers = mutableListOf<String>()
+        didDoc.publicKey.forEach { pubKey ->
+            if (pubKey.ethereumAddress != null) {
+                revokers.add(pubKey.ethereumAddress as String)
+            }
         }
 
         val issuer = didDoc.id as String
         if (issuer.startsWith("did:ethr")) {
-            revokers.toMutableList().add(extractAddress(issuer))
+            revokers.add(extractAddress(issuer))
         }
 
         return revokers

--- a/ethr-status/src/main/java/me/uport/sdk/ethr_status/EthrStatusResolver.kt
+++ b/ethr-status/src/main/java/me/uport/sdk/ethr_status/EthrStatusResolver.kt
@@ -97,7 +97,7 @@ class EthrStatusResolver : StatusResolver {
             revokers.add(extractAddress(issuer))
         }
 
-        return revokers
+        return revokers.distinct()
     }
 
     /*

--- a/ethr-status/src/main/java/me/uport/sdk/ethr_status/RevocationContract.kt
+++ b/ethr-status/src/main/java/me/uport/sdk/ethr_status/RevocationContract.kt
@@ -1,10 +1,16 @@
-@file:Suppress("UndocumentedPublicFunction", "UndocumentedPublicClass")
+@file:Suppress("UndocumentedPublicFunction", "UndocumentedPublicClass", "unused")
+
 package me.uport.sdk.ethr_status
 
 import pm.gnosis.model.Solidity
 import pm.gnosis.model.SolidityBase
 
-class Revocation {
+/**
+ * Encodes and decodes calls to the ethr-status-registry contract.
+ *
+ * This class was generated using the bivrost tools
+ */
+class RevocationContract {
     object Revoked {
         private const val METHOD_ID: String = "e46e3846"
 

--- a/ethr-status/src/test/java/me/uport/sdk/ethr_status/EthrStatusResolverTests.kt
+++ b/ethr-status/src/test/java/me/uport/sdk/ethr_status/EthrStatusResolverTests.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UndocumentedPublicFunction", "UndocumentedPublicClass")
+@file:Suppress("UndocumentedPublicFunction", "UndocumentedPublicClass", "StringLiteralDuplication")
 package me.uport.sdk.ethr_status
 
 import assertk.assertThat

--- a/ethr-status/src/test/java/me/uport/sdk/ethr_status/EthrStatusResolverTests.kt
+++ b/ethr-status/src/test/java/me/uport/sdk/ethr_status/EthrStatusResolverTests.kt
@@ -5,6 +5,7 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import kotlinx.coroutines.runBlocking
+import me.uport.sdk.ethrdid.EthrDIDDocument
 import me.uport.sdk.testhelpers.coAssert
 import org.junit.Test
 import java.math.BigInteger
@@ -16,26 +17,62 @@ class EthrStatusResolverTests {
     @Test
     fun `returns false for valid credentials`() = runBlocking {
 
+        val didDoc = EthrDIDDocument.fromJson(
+            """{
+                "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                "publicKey": [],
+                "authentication": [{
+                    "type": "Secp256k1SignatureAuthentication2018",
+                    "publicKey": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
+                }],
+                "service": [],
+                "@context": "https://w3id.org/did/v1"
+            }"""
+        )
         val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzI5NzM2MjMsInN0YXR1cyI6eyJ0eXBlIjoiRXRoclN0YXR1c1JlZ2lzdHJ5MjAxOSIsImlkIjoicmlua2VieToweDFFNDY1MWRjYTVFZjM4NjM2ZTJFNEQ3QTZGZjRkMjQxM2ZDNTY0NTAifSwiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0.CFDlVKGWBiJwUwq14waLQ2fqLljhJG3Qci5KFhcF8zM916sN7MWFESdF1TseIOPmIcteQ_99m61dTTJ0YMY0rwE"
-        val result = ethrStatus.checkStatus(token)
+        val result = ethrStatus.checkStatus(token, didDoc)
         assertThat(result).isEqualTo(EthrStatus(BigInteger.ZERO))
     }
 
     @Test
     fun `returns true for revoked credentials`() = runBlocking {
 
+        val didDoc = EthrDIDDocument.fromJson(
+            """{
+                "id": "did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229",
+                "publicKey": [],
+                "authentication": [{
+                    "type": "Secp256k1SignatureAuthentication2018",
+                    "publicKey": "did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229#owner"
+                }],
+                "service": [],
+                "@context": "https://w3id.org/did/v1"
+            }"""
+        )
         val token =
             "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzMwNDczNTEsInN0YXR1cyI6eyJ0eXBlIjoiRXRoclN0YXR1c1JlZ2lzdHJ5MjAxOSIsImlkIjoicmlua2VieToweDFFNDY1MWRjYTVFZjM4NjM2ZTJFNEQ3QTZGZjRkMjQxM2ZDNTY0NTAifSwiaXNzIjoiZGlkOmV0aHI6MHgxZmNmOGZmNzhhYzUxMTdkOWM5OWI4MzBjNzRiNjY2OGQ2YWMzMjI5In0.MHabafA0UxJuQJ0Z-7Egb57WRlgj4_zf96B0LUhRyXgVDU5RABIczTTTXWjcuKVzhJc_-FuhRI8uQYmQQNxKzgA"
-        val result = ethrStatus.checkStatus(token)
+        val result = ethrStatus.checkStatus(token, didDoc)
         assertThat(result).isEqualTo(EthrStatus(BigInteger.ONE))
     }
 
     @Test
     fun `throws error for unknown status entry`() = runBlocking {
 
+        val didDoc = EthrDIDDocument.fromJson(
+            """{
+                "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                "publicKey": [],
+                "authentication": [{
+                    "type": "Secp256k1SignatureAuthentication2018",
+                    "publicKey": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
+                }],
+                "service": [],
+                "@context": "https://w3id.org/did/v1"
+            }"""
+        )
         val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzI5NjY3ODAsInN0YXR1cyI6eyJ0eXBlIjoidW5rbm93biIsImlkIjoic29tZXRoaW5nIHNvbWV0aGluZyJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.WO4kUEYy3xzZR1VlofOm3e39e1XM227uIr-Z7Yb9YQcJJ-2PRcnQmecW5fDjIfF3EInS3rRd4TZmuVQOnhaKQAE\n"
         coAssert {
-            ethrStatus.checkStatus(token)
+            ethrStatus.checkStatus(token, didDoc)
         }.thrownError {
             isInstanceOf(IllegalStateException::class)
         }

--- a/ethr-status/src/test/java/me/uport/sdk/ethr_status/EthrStatusResolverTests.kt
+++ b/ethr-status/src/test/java/me/uport/sdk/ethr_status/EthrStatusResolverTests.kt
@@ -1,4 +1,5 @@
 @file:Suppress("UndocumentedPublicFunction", "UndocumentedPublicClass", "StringLiteralDuplication")
+
 package me.uport.sdk.ethr_status
 
 import assertk.assertThat
@@ -29,7 +30,8 @@ class EthrStatusResolverTests {
                 "@context": "https://w3id.org/did/v1"
             }"""
         )
-        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzI5NzM2MjMsInN0YXR1cyI6eyJ0eXBlIjoiRXRoclN0YXR1c1JlZ2lzdHJ5MjAxOSIsImlkIjoicmlua2VieToweDFFNDY1MWRjYTVFZjM4NjM2ZTJFNEQ3QTZGZjRkMjQxM2ZDNTY0NTAifSwiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0.CFDlVKGWBiJwUwq14waLQ2fqLljhJG3Qci5KFhcF8zM916sN7MWFESdF1TseIOPmIcteQ_99m61dTTJ0YMY0rwE"
+        val token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzI5NzM2MjMsInN0YXR1cyI6eyJ0eXBlIjoiRXRoclN0YXR1c1JlZ2lzdHJ5MjAxOSIsImlkIjoicmlua2VieToweDFFNDY1MWRjYTVFZjM4NjM2ZTJFNEQ3QTZGZjRkMjQxM2ZDNTY0NTAifSwiaXNzIjoiZGlkOmV0aHI6MHhmM2JlYWMzMGM0OThkOWUyNjg2NWYzNGZjYWE1N2RiYjkzNWIwZDc0In0.CFDlVKGWBiJwUwq14waLQ2fqLljhJG3Qci5KFhcF8zM916sN7MWFESdF1TseIOPmIcteQ_99m61dTTJ0YMY0rwE"
         val result = ethrStatus.checkStatus(token, didDoc)
         assertThat(result).isEqualTo(EthrStatus(BigInteger.ZERO))
     }
@@ -41,14 +43,14 @@ class EthrStatusResolverTests {
             """{
                 "id": "did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229",
                 "publicKey": [{
-                            "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                            "id": "did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229#owner",
                             "type": "Secp256k1VerificationKey2018",
-                            "owner": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
-                            "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+                            "owner": "did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229",
+                            "ethereumAddress": "0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229"
                         },{
-                            "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                            "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#key-1",
                             "type": "Secp256k1VerificationKey2018",
-                            "owner": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                            "owner": "did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229",
                             "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
                         }],
                 "authentication": [{
@@ -80,34 +82,12 @@ class EthrStatusResolverTests {
                 "@context": "https://w3id.org/did/v1"
             }"""
         )
-        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzI5NjY3ODAsInN0YXR1cyI6eyJ0eXBlIjoidW5rbm93biIsImlkIjoic29tZXRoaW5nIHNvbWV0aGluZyJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.WO4kUEYy3xzZR1VlofOm3e39e1XM227uIr-Z7Yb9YQcJJ-2PRcnQmecW5fDjIfF3EInS3rRd4TZmuVQOnhaKQAE\n"
+        val token =
+            "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzI5NjY3ODAsInN0YXR1cyI6eyJ0eXBlIjoidW5rbm93biIsImlkIjoic29tZXRoaW5nIHNvbWV0aGluZyJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.WO4kUEYy3xzZR1VlofOm3e39e1XM227uIr-Z7Yb9YQcJJ-2PRcnQmecW5fDjIfF3EInS3rRd4TZmuVQOnhaKQAE\n"
         coAssert {
             ethrStatus.checkStatus(token, didDoc)
         }.thrownError {
             isInstanceOf(IllegalStateException::class)
-        }
-    }
-
-    @Test
-    fun `throws error when issuer and diddoc controller are not the same`() = runBlocking {
-
-        val didDoc = EthrDIDDocument.fromJson(
-            """{
-                "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935s0d74",
-                "publicKey": [],
-                "authentication": [{
-                    "type": "Secp256k1SignatureAuthentication2018",
-                    "publicKey": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
-                }],
-                "service": [],
-                "@context": "https://w3id.org/did/v1"
-            }"""
-        )
-        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzI5NjY3ODAsInN0YXR1cyI6eyJ0eXBlIjoidW5rbm93biIsImlkIjoic29tZXRoaW5nIHNvbWV0aGluZyJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.WO4kUEYy3xzZR1VlofOm3e39e1XM227uIr-Z7Yb9YQcJJ-2PRcnQmecW5fDjIfF3EInS3rRd4TZmuVQOnhaKQAE\n"
-        coAssert {
-            ethrStatus.checkStatus(token, didDoc)
-        }.thrownError {
-            isInstanceOf(IllegalArgumentException::class)
         }
     }
 }

--- a/ethr-status/src/test/java/me/uport/sdk/ethr_status/EthrStatusResolverTests.kt
+++ b/ethr-status/src/test/java/me/uport/sdk/ethr_status/EthrStatusResolverTests.kt
@@ -77,4 +77,27 @@ class EthrStatusResolverTests {
             isInstanceOf(IllegalStateException::class)
         }
     }
+
+    @Test
+    fun `throws error when issuer and diddoc controller are not the same`() = runBlocking {
+
+        val didDoc = EthrDIDDocument.fromJson(
+            """{
+                "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935s0d74",
+                "publicKey": [],
+                "authentication": [{
+                    "type": "Secp256k1SignatureAuthentication2018",
+                    "publicKey": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
+                }],
+                "service": [],
+                "@context": "https://w3id.org/did/v1"
+            }"""
+        )
+        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOjE1NzI5NjY3ODAsInN0YXR1cyI6eyJ0eXBlIjoidW5rbm93biIsImlkIjoic29tZXRoaW5nIHNvbWV0aGluZyJ9LCJpc3MiOiJkaWQ6ZXRocjoweGYzYmVhYzMwYzQ5OGQ5ZTI2ODY1ZjM0ZmNhYTU3ZGJiOTM1YjBkNzQifQ.WO4kUEYy3xzZR1VlofOm3e39e1XM227uIr-Z7Yb9YQcJJ-2PRcnQmecW5fDjIfF3EInS3rRd4TZmuVQOnhaKQAE\n"
+        coAssert {
+            ethrStatus.checkStatus(token, didDoc)
+        }.thrownError {
+            isInstanceOf(IllegalArgumentException::class)
+        }
+    }
 }

--- a/ethr-status/src/test/java/me/uport/sdk/ethr_status/EthrStatusResolverTests.kt
+++ b/ethr-status/src/test/java/me/uport/sdk/ethr_status/EthrStatusResolverTests.kt
@@ -40,7 +40,17 @@ class EthrStatusResolverTests {
         val didDoc = EthrDIDDocument.fromJson(
             """{
                 "id": "did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229",
-                "publicKey": [],
+                "publicKey": [{
+                            "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                            "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+                        },{
+                            "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                            "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+                        }],
                 "authentication": [{
                     "type": "Secp256k1SignatureAuthentication2018",
                     "publicKey": "did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229#owner"

--- a/ethr-status/src/test/java/me/uport/sdk/ethr_status/ValidRevokersTests.kt
+++ b/ethr-status/src/test/java/me/uport/sdk/ethr_status/ValidRevokersTests.kt
@@ -28,4 +28,109 @@ class ValidRevokersTests {
         val revokers = ethrStatus.getValidRevokers(didDoc)
         assertThat(revokers).isEqualTo(listOf("0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229"))
     }
+
+    @Test
+    fun `can generate list of revokers with publickey entries and ethr-did issuer`() {
+
+        val didDoc = EthrDIDDocument.fromJson(
+            """{
+                        "id": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
+                        "publicKey": [{
+                            "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                            "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+                        },{
+                            "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                            "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+                        }],
+                        "authentication": [{
+                            "type": "Secp256k1SignatureAuthentication2018",
+                            "publicKey": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
+                        }],
+                        "service": [],
+                        "@context": "https://w3id.org/did/v1"
+                    }"""
+        )
+
+        val revokers = ethrStatus.getValidRevokers(didDoc)
+        assertThat(revokers).isEqualTo(listOf("0xf3beac30c498d9e26865f34fcaa57dbb935b0d74", "0x108209f4247b7fe6605b0f58f9145ec3269d0154"))
+    }
+
+    @Test
+    fun `can generate list of revokers with publickey entries and non ethr-did issuer`() {
+
+        val didDoc = EthrDIDDocument.fromJson(
+            """{
+                        "id": "did:uport:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
+                        "publicKey": [{
+                            "id": "did:uport:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:uport:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                            "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+                        },{
+                            "id": "did:uport:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:uport:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                            "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+                        }],
+                        "authentication": [{
+                            "type": "Secp256k1SignatureAuthentication2018",
+                            "publicKey": "did:uport:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
+                        }],
+                        "service": [],
+                        "@context": "https://w3id.org/did/v1"
+                    }"""
+        )
+
+        val revokers = ethrStatus.getValidRevokers(didDoc)
+        assertThat(revokers).isEqualTo(listOf("0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"))
+    }
+
+    @Test
+    fun `generates a distinct list of revokers`() {
+
+        val didDoc = EthrDIDDocument.fromJson(
+            """{
+                        "id": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
+                        "publicKey": [{
+                            "id": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#keys-1",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
+                            "ethereumAddress": "0x108209f4247b7fe6605b0f58f9145ec3269d0154"
+                        },{
+                            "id": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#keys-2",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
+                            "ethereumAddress": "0x108209f4247b7fe6605b0f58f9145ec3269d0154"
+                        },{
+                            "id": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#keys-2",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
+                            "ethereumAddress": "0x108209f4247b7fe6605b0f58f9145ec3269d0154"
+                        },{
+                            "id": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#keys-3",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
+                            "ethereumAddress": "0x108209f4247b7fe6605b0f58f9145ec3269d0154"
+                        },{
+                            "id": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#keys-4",
+                            "type": "Secp256k1VerificationKey2018",
+                            "owner": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
+                            "ethereumAddress": "0x108209f4247b7fe6605b0f58f9145ec3269d0154"
+                        }],
+                        "authentication": [{
+                            "type": "Secp256k1SignatureAuthentication2018",
+                            "publicKey": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner"
+                        }],
+                        "service": [],
+                        "@context": "https://w3id.org/did/v1"
+                    }"""
+        )
+
+        val revokers = ethrStatus.getValidRevokers(didDoc)
+        assertThat(revokers).isEqualTo(listOf("0x108209f4247b7fe6605b0f58f9145ec3269d0154"))
+    }
 }

--- a/ethr-status/src/test/java/me/uport/sdk/ethr_status/ValidRevokersTests.kt
+++ b/ethr-status/src/test/java/me/uport/sdk/ethr_status/ValidRevokersTests.kt
@@ -1,3 +1,4 @@
+@file:Suppress("UndocumentedPublicFunction", "UndocumentedPublicClass", "StringLiteralDuplication")
 package me.uport.sdk.ethr_status
 
 import assertk.assertThat

--- a/ethr-status/src/test/java/me/uport/sdk/ethr_status/ValidRevokersTests.kt
+++ b/ethr-status/src/test/java/me/uport/sdk/ethr_status/ValidRevokersTests.kt
@@ -1,4 +1,5 @@
 @file:Suppress("UndocumentedPublicFunction", "UndocumentedPublicClass", "StringLiteralDuplication")
+
 package me.uport.sdk.ethr_status
 
 import assertk.assertThat
@@ -27,7 +28,7 @@ class ValidRevokersTests {
         )
 
         val revokers = ethrStatus.getValidRevokers(didDoc)
-        assertThat(revokers).isEqualTo(listOf("0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229"))
+        assertThat(revokers).isEqualTo(emptyList<String>())
     }
 
     @Test
@@ -37,14 +38,14 @@ class ValidRevokersTests {
             """{
                         "id": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
                         "publicKey": [{
-                            "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                            "id": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#owner",
                             "type": "Secp256k1VerificationKey2018",
-                            "owner": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
-                            "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+                            "owner": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
+                            "ethereumAddress": "0x108209f4247b7fe6605b0f58f9145ec3269d0154"
                         },{
-                            "id": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner",
+                            "id": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154#key-1",
                             "type": "Secp256k1VerificationKey2018",
-                            "owner": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74",
+                            "owner": "did:ethr:0x108209f4247b7fe6605b0f58f9145ec3269d0154",
                             "ethereumAddress": "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
                         }],
                         "authentication": [{
@@ -57,7 +58,12 @@ class ValidRevokersTests {
         )
 
         val revokers = ethrStatus.getValidRevokers(didDoc)
-        assertThat(revokers).isEqualTo(listOf("0xf3beac30c498d9e26865f34fcaa57dbb935b0d74", "0x108209f4247b7fe6605b0f58f9145ec3269d0154"))
+        assertThat(revokers).isEqualTo(
+            listOf(
+                "0x108209f4247b7fe6605b0f58f9145ec3269d0154",
+                "0xf3beac30c498d9e26865f34fcaa57dbb935b0d74"
+            )
+        )
     }
 
     @Test

--- a/ethr-status/src/test/java/me/uport/sdk/ethr_status/ValidRevokersTests.kt
+++ b/ethr-status/src/test/java/me/uport/sdk/ethr_status/ValidRevokersTests.kt
@@ -61,7 +61,7 @@ class ValidRevokersTests {
     }
 
     @Test
-    fun `can generate list of revokers with publickey entries and non ethr-did issuer`() {
+    fun `can generate list of revokers with public key entries and non ethr-did issuer`() {
 
         val didDoc = EthrDIDDocument.fromJson(
             """{

--- a/ethr-status/src/test/java/me/uport/sdk/ethr_status/ValidRevokersTests.kt
+++ b/ethr-status/src/test/java/me/uport/sdk/ethr_status/ValidRevokersTests.kt
@@ -1,0 +1,31 @@
+package me.uport.sdk.ethr_status
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import me.uport.sdk.ethrdid.EthrDIDDocument
+import org.junit.Test
+
+class ValidRevokersTests {
+
+    private val ethrStatus = EthrStatusResolver()
+
+    @Test
+    fun `can generate list of revokers when no publickey entries`() {
+
+        val didDoc = EthrDIDDocument.fromJson(
+            """{
+                "id": "did:ethr:0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229",
+                "publicKey": [],
+                "authentication": [{
+                    "type": "Secp256k1SignatureAuthentication2018",
+                    "publicKey": "did:ethr:0xf3beac30c498d9e26865f34fcaa57dbb935b0d74#owner"
+                }],
+                "service": [],
+                "@context": "https://w3id.org/did/v1"
+            }"""
+        )
+
+        val revokers = ethrStatus.getValidRevokers(didDoc)
+        assertThat(revokers).isEqualTo(listOf("0x1fcf8ff78ac5117d9c99b830c74b6668d6ac3229"))
+    }
+}

--- a/uport-did/build.gradle
+++ b/uport-did/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     testImplementation "junit:junit:$junit_version"
     testImplementation "io.mockk:mockk:$mockk_version"
     testImplementation "com.willowtreeapps.assertk:assertk-jvm:$assertk_version"
+    testImplementation "com.squareup.okhttp3:okhttp:$okhttp_version"
 }


### PR DESCRIPTION
#### What's Here

This resolves the issue https://github.com/uport-project/kotlin-did-jwt/issues/38

This PR enables support for non-ethr-did addresses by creating a list of revokers from the public key entries in the did document.

#### Testing

Verified that the previous tests still pass and added new tests to validate the process of creating the list of revokers.